### PR TITLE
Explicitly assign a color to the edit button

### DIFF
--- a/src/Components/Confirmation/Confirmation.css
+++ b/src/Components/Confirmation/Confirmation.css
@@ -15,6 +15,10 @@
   margin-left: 10%;
 }
 
+.MuiSvgIcon-root.edit-icon {
+  color: #2a2b2a;
+}
+
 .edit-icon:hover {
   cursor: pointer;
 }
@@ -41,6 +45,10 @@
   color: #2a2b2a;
   height: 4rem;
   width: 4rem;
+}
+
+.MuiSvgIcon-root.edit-button {
+  color: #2a2b2a;
 }
 
 @media (max-width: 630px) {

--- a/src/Components/Confirmation/Confirmation.css
+++ b/src/Components/Confirmation/Confirmation.css
@@ -47,10 +47,6 @@
   width: 4rem;
 }
 
-.MuiSvgIcon-root.edit-button {
-  color: #2a2b2a;
-}
-
 @media (max-width: 630px) {
   .confirmation-container {
     margin: 0;


### PR DESCRIPTION
What (if anything) did you refactor?
- I added a color property to the edit button

Were there any issues that arose?
- I tested this on the desktop Safari browser and the icons were black.