### PR TITLE
Refactor/2 1 1 table display

### DIFF
--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -678,11 +678,7 @@ const Results = () => {
                 {displayBenefitAndImmedNeedsBtns()}
                 {filterResultsButton === 'benefits' && renderDataGridOrNoResultsTable()}
                 {filterResultsButton === 'urgentNeeds' && (
-                  <UrgentNeedsTable
-                    urgentNeedsPrograms={results.rawResponse.urgent_needs}
-                    locale={locale}
-                    totalEligiblePrograms={totalEligiblePrograms(results.programs)}
-                  />
+                  <UrgentNeedsTable urgentNeedsPrograms={results.rawResponse.urgent_needs} locale={locale} />
                 )}
               </Grid>
               <Button

--- a/src/Components/UrgentNeedsTable/UrgentNeedsTable.js
+++ b/src/Components/UrgentNeedsTable/UrgentNeedsTable.js
@@ -10,7 +10,7 @@ import UrgentNeedsRow from './UrgentNeedsRow';
 import { FormattedMessage } from 'react-intl';
 import './UrgentNeedsTable.css';
 
-const UrgentNeedsTable = ({ urgentNeedsPrograms, locale, totalEligiblePrograms }) => {
+const UrgentNeedsTable = ({ urgentNeedsPrograms, locale }) => {
   const finalUrgentNeedsPrograms = urgentNeedsPrograms[locale.toLowerCase()];
 
   const displayFooter = () => {
@@ -82,13 +82,11 @@ const UrgentNeedsTable = ({ urgentNeedsPrograms, locale, totalEligiblePrograms }
             <UrgentNeedsRow key={row.name} rowProps={row} />
           ))}
         </TableBody>
-        {!totalEligiblePrograms && (
-          <TableFooter>
-            <TableRow>
-              <TableCell colSpan={3}>{displayFooter()}</TableCell>
-            </TableRow>
-          </TableFooter>
-        )}
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={3}>{displayFooter()}</TableCell>
+          </TableRow>
+        </TableFooter>
       </Table>
     </TableContainer>
   );

--- a/src/Components/UrgentNeedsTable/UrgentNeedsTable.js
+++ b/src/Components/UrgentNeedsTable/UrgentNeedsTable.js
@@ -25,7 +25,7 @@ const UrgentNeedsTable = ({ urgentNeedsPrograms, locale, totalEligiblePrograms }
               rel="noreferrer"
               href="https://www.211colorado.org/"
             >
-              Colorado 2-1-1
+              2-1-1 Colorado
             </a>
             <FormattedMessage
               id="noResults.p-Three"
@@ -51,7 +51,7 @@ const UrgentNeedsTable = ({ urgentNeedsPrograms, locale, totalEligiblePrograms }
               rel="noreferrer"
               href="https://www.211colorado.org/"
             >
-              Colorado 2-1-1
+              2-1-1 Colorado
             </a>
             <FormattedMessage
               id="noResults.p-Three"


### PR DESCRIPTION
What (if any) features are you implementing?
- The `Immediate Needs` 2-1-1 row comes up regardless of benefits results.

No `Immediate Needs` selected: 
<img width="1724" alt="Screenshot 2023-08-04 at 2 10 35 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/9880f661-db9d-413a-a970-8ecf09233da8">
<img width="1728" alt="Screenshot 2023-08-04 at 2 26 48 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/30fdd037-056f-4b2c-a77a-2703f622320e">

`Immediate Needs` selected: 
<img width="1725" alt="Screenshot 2023-08-04 at 2 10 11 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/084a5949-5273-4f6e-a309-46466b9f7e10">
<img width="1728" alt="Screenshot 2023-08-04 at 2 27 10 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/5d08ebe8-d40f-4fcb-a267-54504fe9ed93">
