### PR TITLE
Don't Show Errors When Follow Up Questions Are Shown

### DIFF
--- a/src/Components/Share/Share.js
+++ b/src/Components/Share/Share.js
@@ -1,4 +1,4 @@
-import { forwardRef, useContext, useState } from 'react';
+import { forwardRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import {
   EmailShareButton,
@@ -18,11 +18,9 @@ import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 import ReactGA from 'react-ga4';
 import './Share.css';
-import Wrapper from '../Wrapper/Wrapper';
 
 const Share = forwardRef(function Share({ close }, ref) {
   const [copied, setCopied] = useState(false);
-  const { formData } = useContext(Wrapper);
   const intl = useIntl();
 
   const labels = {
@@ -40,7 +38,7 @@ const Share = forwardRef(function Share({ close }, ref) {
     }),
   };
 
-  const shareUrl = `https://www.myfriendben.org/?referrer=${formData.refferrerCode}`;
+  const shareUrl = 'https://www.myfriendben.org/';
   const appId = '1268913277361574';
 
   const iconSize = { fontSize: '1.3rem' };


### PR DESCRIPTION
What (if any) features are you implementing?
- No longer show error messages when follow up questions are shown.

What (if anything) did you refactor?
- Make isSubmitted into timesSubmitted as a number.
