### PR TITLE
Convert externalId to string type, rm Num type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,8 @@ const App = () => {
   const urlSearchParams = location.search;
   const [searchParams] = useSearchParams();
   const isTest = searchParams.get('test') ? true : false;
-  const externalId = searchParams.get('externalid') ? Number(searchParams.get('externalid')) : undefined;
+  const rawExternalId = searchParams.get('externalid');
+  const externalId = rawExternalId !== null ? rawExternalId : undefined;
   const referrer = searchParams.get('referrer') !== null ? (searchParams.get('referrer') as string) : '';
   const referrerSource = referrer in referralOptions ? referrer : '';
   const totalSteps = Object.keys(stepDirectory).length + 2;

--- a/src/Types/FormData.ts
+++ b/src/Types/FormData.ts
@@ -85,7 +85,7 @@ export interface AcuteHHConditions {
 
 export interface FormData {
   isTest?: boolean;
-  externalID?: number;
+  externalID?: string;
   agreeToTermsOfService: boolean;
   zipcode: string;
   county: string;


### PR DESCRIPTION
What (if any) features are you implementing?
- I converted the `externalId` to a string type to resolve the `null` field issue that's coming up on our dashboard.