### PR TITLE
Add Edit Icon to Household Members

### DIFF
--- a/src/Components/HouseholdDataBlock/HouseholdDataBlock.css
+++ b/src/Components/HouseholdDataBlock/HouseholdDataBlock.css
@@ -2,10 +2,21 @@
   display: inline-flex;
   flex-direction: column;
   flex-wrap: wrap;
-  border: 1px solid black;
+  outline: 1px solid black;
   border-radius: 10px;
   padding: 0.7rem;
   margin: 0.5rem;
+  position: relative;
+}
+
+.household-member-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.current-household-member {
+  outline: 3px solid var(--primary-color);
   box-shadow: 1px 1px 10px rgb(0 0 0 / 0.4);
 }
 

--- a/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
+++ b/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
@@ -21,7 +21,9 @@ import { FormattedMessage } from 'react-intl';
 import { getStepNumber } from '../../Assets/stepDirectory';
 import PreviousButton from '../PreviousButton/PreviousButton';
 import { Context } from '../Wrapper/Wrapper.tsx';
+import EditIcon from '@mui/icons-material/Edit';
 import './HouseholdDataBlock.css';
+import { IconButton } from '@mui/material';
 
 const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
   const { formData } = useContext(Context);
@@ -201,8 +203,19 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
     }
 
     return (
-      <article className="member-added-container" key={index}>
-        <h3 className="member-added-relationship">{relationship}:</h3>
+      <article className={`member-added-container ${index + 1 === page ? 'current-household-member' : ''}`} key={index}>
+        <div className="household-member-header">
+          <h3 className="member-added-relationship">{relationship}:</h3>
+          <div className="household-member-edit-button">
+            <IconButton
+              onClick={() => {
+                navigate(`/${uuid}/step-${step}/${index + 1}`);
+              }}
+            >
+              <EditIcon />
+            </IconButton>
+          </div>
+        </div>
         <div className="member-added-age">
           <FormattedMessage id="questions.age-inputLabel" defaultMessage="Age" />: {age}
         </div>

--- a/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
+++ b/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
@@ -202,8 +202,10 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
       income += Number(num);
     }
 
+    const containerClassName = `member-added-container ${index + 1 === page ? 'current-household-member' : ''}`;
+
     return (
-      <article className={`member-added-container ${index + 1 === page ? 'current-household-member' : ''}`} key={index}>
+      <article className={containerClassName} key={index}>
         <div className="household-member-header">
           <h3 className="member-added-relationship">{relationship}:</h3>
           <div className="household-member-edit-button">


### PR DESCRIPTION
What (if any) features are you implementing?
- Add edit icon to household members.
- Add outline to show the household member that you are on.

### Desktop:
![image](https://github.com/Gary-Community-Ventures/benefits-calculator/assets/62856626/8168f075-a53e-4b52-b921-e966a05f77b8)
### 211:
![image](https://github.com/Gary-Community-Ventures/benefits-calculator/assets/62856626/912ef34c-8d12-43b0-8c11-f4ba7ee5807e)
### Mobile:
![image](https://github.com/Gary-Community-Ventures/benefits-calculator/assets/62856626/d68a4b69-96ab-4418-9544-b6ad95ba423c)

