### PR TITLE
Refactor/results header

### DIFF
--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -122,7 +122,7 @@ const Results = () => {
   const [citizenshipRowCount, setCitizenshipRowCount] = useState(1);
   const [totalCitizenshipDollarValue, setTotalCitizenshipDollarValue] = useState({
     cashOrReducedExpenses: 0,
-    taxCredits: 0
+    taxCredits: 0,
   });
   const [totalVisibleRowDollarValue, setTotalVisibleRowDollarValue] = useState(0);
   const apiRef = useGridApiRef();
@@ -144,24 +144,27 @@ const Results = () => {
 
     //used categoryValues(eligiblePrograms) instead of the real total to take into account the preschool category value cap at 8640
     const allCategoriesAndValuesObjCappedForPreschool = categoryValues(eligiblePrograms);
-    const totalCashAndTaxCreditValues = Object.entries(allCategoriesAndValuesObjCappedForPreschool).reduce((acc, categoryAndValueArr) => {
-      const categoryName = categoryAndValueArr[0];
-      const categoryValue = categoryAndValueArr[1];
-      const taxCreditsCategoryString = 'Tax Credits';
+    const totalCashAndTaxCreditValues = Object.entries(allCategoriesAndValuesObjCappedForPreschool).reduce(
+      (acc, categoryAndValueArr) => {
+        const categoryName = categoryAndValueArr[0];
+        const categoryValue = categoryAndValueArr[1];
+        const taxCreditsCategoryString = 'Tax Credits';
 
-      if (categoryName === taxCreditsCategoryString) {
-        acc.taxCredits += categoryValue;
-      } else {
-        acc.cashOrReducedExp += categoryValue;
-      }
+        if (categoryName === taxCreditsCategoryString) {
+          acc.taxCredits += categoryValue;
+        } else {
+          acc.cashOrReducedExp += categoryValue;
+        }
 
-      return acc;
-    }, {cashOrReducedExp: 0, taxCredits: 0});
+        return acc;
+      },
+      { cashOrReducedExp: 0, taxCredits: 0 },
+    );
 
     setCitizenshipRowCount(count);
     setTotalCitizenshipDollarValue({
       cashOrReducedExpenses: totalCashAndTaxCreditValues.cashOrReducedExp,
-      taxCredits: totalCashAndTaxCreditValues.taxCredits
+      taxCredits: totalCashAndTaxCreditValues.taxCredits,
     });
 
     //this is for the category header

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -120,7 +120,10 @@ const Results = () => {
   });
 
   const [citizenshipRowCount, setCitizenshipRowCount] = useState(1);
-  const [totalCitizenshipDollarValue, setTotalCitizenshipDollarValue] = useState(0);
+  const [totalCitizenshipDollarValue, setTotalCitizenshipDollarValue] = useState({
+    cashOrReducedExpenses: 0,
+    taxCredits: 0
+  });
   const [totalVisibleRowDollarValue, setTotalVisibleRowDollarValue] = useState(0);
   const apiRef = useGridApiRef();
 

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -688,7 +688,7 @@ const Results = () => {
               </span>
             </Toolbar>
             {currentCategory.defaultMessage ===
-              categories.find((cat) => cat.defaultMessage === preschoolProgramCategory)?.defaultMessage && (
+              categories.find((cat) => cat.defaultMessage === preschoolProgramCategoryString)?.defaultMessage && (
               <Typography variant="body2" className="child-care-helper-text">
                 <FormattedMessage
                   id="benefitCategories.childCareHelperText"

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -385,13 +385,13 @@ const Results = () => {
               id="results.return-programsUpToLabel"
               defaultMessage=" programs with an estimated value of "
             />
-            ${totalCitizenshipDollarValue.toLocaleString()}
-            <FormattedMessage id="results.return-perYearOrLabel" defaultMessage=" per year or " />$
-            {Math.round(totalCitizenshipDollarValue / 12).toLocaleString()}
+            ${Math.round(totalCitizenshipDollarValue.cashOrReducedExpenses / 12).toLocaleString()}
             <FormattedMessage
               id="results.return-perMonthLabel"
-              defaultMessage=" per month in cash or reduced expenses for you to consider"
+              defaultMessage=" monthly in cash or reduced expenses, and "
             />
+            ${Math.round(totalCitizenshipDollarValue.taxCredits).toLocaleString()}
+            <FormattedMessage id="results.return-taxCredits" defaultMessage=" in tax credits for you to consider " />
           </h1>
         </Grid>
       );

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -142,14 +142,27 @@ const Results = () => {
       }
     });
 
-    //used this instead of the real total to take into account the preschool category value cap at 8640
-    const categoryValuesArray = Object.values(categoryValues(eligiblePrograms));
-    const cappedCatValuesTotalDollarAmount = categoryValuesArray.reduce((acc, categoryAmt) => {
-      return (acc += categoryAmt);
-    }, 0);
+    //used categoryValues(eligiblePrograms) instead of the real total to take into account the preschool category value cap at 8640
+    const allCategoriesAndValuesObjCappedForPreschool = categoryValues(eligiblePrograms);
+    const totalCashAndTaxCreditValues = Object.entries(allCategoriesAndValuesObjCappedForPreschool).reduce((acc, categoryAndValueArr) => {
+      const categoryName = categoryAndValueArr[0];
+      const categoryValue = categoryAndValueArr[1];
+      const taxCreditsCategoryString = 'Tax Credits';
+
+      if (categoryName === taxCreditsCategoryString) {
+        acc.taxCredits += categoryValue;
+      } else {
+        acc.cashOrReducedExp += categoryValue;
+      }
+
+      return acc;
+    }, {cashOrReducedExp: 0, taxCredits: 0});
 
     setCitizenshipRowCount(count);
-    setTotalCitizenshipDollarValue(cappedCatValuesTotalDollarAmount);
+    setTotalCitizenshipDollarValue({
+      cashOrReducedExpenses: totalCashAndTaxCreditValues.cashOrReducedExp,
+      taxCredits: totalCashAndTaxCreditValues.taxCredits
+    });
 
     //this is for the category header
     if (apiRef && apiRef.current && Object.keys(apiRef.current).length) {
@@ -159,7 +172,7 @@ const Results = () => {
 
       //this is only to cap the totalVisibleRowDollarValue for preschool
       const typedFiltCategory = filt.category as GridFilterItem;
-      if (typedFiltCategory.value === preschoolProgramCategory && updatedTotalEligibleDollarValue > 8640) {
+      if (typedFiltCategory.value === preschoolProgramCategoryString && updatedTotalEligibleDollarValue > 8640) {
         setTotalVisibleRowDollarValue(8640);
         return;
       }

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -216,9 +216,9 @@ const Results = () => {
     });
   };
 
-  const preschoolProgramCategory = 'Child Care, Youth, and Education';
+  const preschoolProgramCategoryString = 'Child Care, Youth, and Education';
   const categoryValues = (programs: Program[]) => {
-    const preschoolPrograms = { numOfPreSchoolPrograms: 0, totalEstVal: 0 }; //i=0 => num of preschool prog, i=1 => prog.est.value
+    const preschoolPrograms = { numOfPreSchoolPrograms: 0, totalEstVal: 0 };
     const categoryValues: { [key: string]: number } = {};
     for (let program of programs) {
       //add this category to the categoryValues dictionary if the key doesn't already exist
@@ -231,8 +231,11 @@ const Results = () => {
       });
 
       if (hasOverlap) {
+        //we add that program's est value to its corresponding categoryValues key
         categoryValues[program.category.default_message] += program.estimated_value;
-        if (program.category.default_message === preschoolProgramCategory) {
+
+        //if the program is a preschoolProgram, we also add it to the preschoolPrograms separately
+        if (program.category.default_message === preschoolProgramCategoryString) {
           preschoolPrograms.numOfPreSchoolPrograms++;
           preschoolPrograms.totalEstVal += program.estimated_value;
         }
@@ -240,7 +243,7 @@ const Results = () => {
     }
 
     if (preschoolPrograms.totalEstVal > 8640 && preschoolPrograms.numOfPreSchoolPrograms > 1) {
-      categoryValues[preschoolProgramCategory] = 8640;
+      categoryValues[preschoolProgramCategoryString] = 8640;
     }
 
     return categoryValues;


### PR DESCRIPTION
ClickUp Ticket: https://app.clickup.com/t/8685uugtv

What (if anything) did you refactor?
- I revised the header language to display a monthly amount that does not include the `Tax Credits` category. Instead, the `Tax Credits` category is displayed afterward as a yearly amount.

Were there any issues that arose?
- Yes, the issue that arose entailed a bug on the backend that was returning a translated `benefit.category.default_message` value based on the locale. This was an issue because we were comparing each of those translated `benefit.category.default_message` category strings with the hard coded English strings of `preschoolProgramCategoryString` and `taxCreditsCategoryString`. As a result the preschool values were not being capped and the taxCredit values weren't getting pulled out of the `totalCitizenshipDollarValue.cashOrReducedExpenses` or added to the `totalCitizenshipDollarValue.taxCredits`. I paired with Caleb and was able to help him fix this backend bug via this [PR](https://github.com/Gary-Community-Ventures/benefits-api/pull/125).

Is there anything that you need from your teammate?
- Please review the PR, checkout the branch and test that each locale's values (e.g. monthly total, tax credits, preschool category cap) are the same as the English one by changing the locale and then hitting refresh on the page.

Any other comments, questions, or concerns?
- This bug is an excellent use case for end to end testing. Ideally we should have tests that check to make sure that the monthly total, tax credit, and preschool values being displayed are the ones we expect when we change locale and refresh the page.
<img width="698" alt="English monthly taxCredit preschool" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/1ab89b34-e79e-40a2-8189-0974d3ee5fd0">
<img width="699" alt="Spanish monthly taxCredit preschool" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/dd7ea131-27b5-4467-ac2a-4ba9c3b664fd">
<img width="698" alt="Vietnamese monthly taxCredit preschool" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/0e54c53a-a46e-4f53-89d6-1db273b47c5e">


