### PR TITLE
Add translatedAriaLabel to the card for dynam 1st tile

### DIFF
--- a/src/Components/HealthInsuranceQ/HealthInsuranceQ.tsx
+++ b/src/Components/HealthInsuranceQ/HealthInsuranceQ.tsx
@@ -84,7 +84,7 @@ const HealthInsuranceQ = ({
         id: 'healthInsuranceOptions.none-I',
         defaultMessage: 'I do not have health insurance',
       });
-
+      
       if (hhMemberIndex === 1 && key === 'none') {
         translatedAriaLabel = youDoNotHaveHealthInsuranceFM;
       }
@@ -111,7 +111,7 @@ const HealthInsuranceQ = ({
               <img src={healthCareOptions[optionKey].image} alt={translatedAriaLabel} />
             </div>
             <CardContent sx={{ textAlign: 'center', padding: '.35rem' }}>
-              <Typography>{healthCareOptions[optionKey].formattedMessage}</Typography>
+              <Typography>{translatedAriaLabel}</Typography>
             </CardContent>
           </Card>
         </CardActionArea>

--- a/src/Components/HealthInsuranceQ/HealthInsuranceQ.tsx
+++ b/src/Components/HealthInsuranceQ/HealthInsuranceQ.tsx
@@ -84,7 +84,7 @@ const HealthInsuranceQ = ({
         id: 'healthInsuranceOptions.none-I',
         defaultMessage: 'I do not have health insurance',
       });
-      
+
       if (hhMemberIndex === 1 && key === 'none') {
         translatedAriaLabel = youDoNotHaveHealthInsuranceFM;
       }


### PR DESCRIPTION
Were there any issues that arose?
- The first tile on the `HealthInsuranceQ` wasn't switching from `I do not have health insurance` to `They do not have health insurance`.  I replaced the existing rendering of the text with the `translatedAriaLabel`.

Updated first tile:
<img width="1109" alt="Screenshot 2023-11-03 at 10 32 38 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/38a56299-1b76-45b6-a1b7-65384e149391">

Second tile:
<img width="1111" alt="Screenshot 2023-11-03 at 10 32 48 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/c56b39b3-6196-4e93-97f9-4bd855229893">

