### PR TITLE
Refactor/childcare cat header value

### DIFF
--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -251,7 +251,8 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
   const preschoolProgramCategoryString = 'Child Care, Youth, and Education';
 
   const renderAllCategoryValues = (programs: Program[]) => {
-    const childCareYouthEdPrograms = { childCareTotalEstVal: 0, youthAndEducationTotalEstVal: 0 };
+    let childCareTotalEstVal = 0;
+    let youthAndEducationTotalEstVal = 0;
     const categoryValues: { [key: string]: number } = {};
 
     for (let program of programs) {
@@ -270,21 +271,23 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
         //we add that program's est value to its corresponding categoryValues key
         categoryValues[program.category.default_message] += program.estimated_value;
 
-        //if the program is a preschoolProgram, we also add it to the childCareYouthEdPrograms separately
+        //if the program is in the preschoolProgramCategory, we also add it to the childCareTotalEstVal or youthAndEducationTotalEstVal separately
         if (isPreschoolOrChildCareProgram) {
-          childCareYouthEdPrograms.childCareTotalEstVal += program.estimated_value;
-        } else if (program.category.default_message === preschoolProgramCategoryString && isPreschoolOrChildCareProgram === false) {
-          childCareYouthEdPrograms.youthAndEducationTotalEstVal += program.estimated_value;
+          childCareTotalEstVal += program.estimated_value;
+        } else if (
+          program.category.default_message === childCareYouthAndEducationCategoryString &&
+          isPreschoolOrChildCareProgram === false
+        ) {
+          youthAndEducationTotalEstVal += program.estimated_value;
         }
       }
     }
 
-    if (childCareYouthEdPrograms.childCareTotalEstVal > 8640) {
-      childCareYouthEdPrograms.childCareTotalEstVal = 8640;
+    if (childCareTotalEstVal > 8640) {
+      childCareTotalEstVal = 8640;
     }
 
-    categoryValues[preschoolProgramCategoryString] =
-      childCareYouthEdPrograms.childCareTotalEstVal + childCareYouthEdPrograms.youthAndEducationTotalEstVal;
+    categoryValues[childCareYouthAndEducationCategoryString] = childCareTotalEstVal + youthAndEducationTotalEstVal;
 
     return categoryValues;
   };

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -191,7 +191,8 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
       //this is only to cap the totalVisibleRowDollarValue for preschool
       const typedFiltCategory = filt.category as GridFilterItem;
       if (typedFiltCategory.value === childCareYouthAndEducationCategoryString) {
-        const childCareYouthAndEducationDollarValue = renderAllCategoryValues(eligiblePrograms)[childCareYouthAndEducationCategoryString];
+        const childCareYouthAndEducationDollarValue =
+          renderAllCategoryValues(eligiblePrograms)[childCareYouthAndEducationCategoryString];
         setTotalVisibleRowDollarValue(childCareYouthAndEducationDollarValue);
         return;
       }
@@ -731,7 +732,8 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
               </span>
             </Toolbar>
             {currentCategory.defaultMessage ===
-              categories.find((cat) => cat.defaultMessage === childCareYouthAndEducationCategoryString)?.defaultMessage && (
+              categories.find((cat) => cat.defaultMessage === childCareYouthAndEducationCategoryString)
+                ?.defaultMessage && (
               <Typography variant="body2" className="child-care-helper-text">
                 <FormattedMessage
                   id="benefitCategories.childCareHelperText"

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -157,7 +157,7 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
       }
     });
 
-    //used renderAllCategoryValues(eligiblePrograms) instead of the real total to take into account the preschool category value cap at 8640
+    //used renderAllCategoryValues(eligiblePrograms) instead of the real total to take into account the preschool/childCare category value cap at 8640
     const allCategoriesAndValuesObjCappedForPreschool = renderAllCategoryValues(eligiblePrograms);
     const totalCashAndTaxCreditValues = Object.entries(allCategoriesAndValuesObjCappedForPreschool).reduce(
       (acc, categoryAndValueArr) => {
@@ -190,9 +190,9 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
 
       //this is only to cap the totalVisibleRowDollarValue for preschool
       const typedFiltCategory = filt.category as GridFilterItem;
-      if (typedFiltCategory.value === preschoolProgramCategoryString) {
-        const preschoolCategoryDollarValue = renderAllCategoryValues(eligiblePrograms)[preschoolProgramCategoryString];
-        setTotalVisibleRowDollarValue(preschoolCategoryDollarValue);
+      if (typedFiltCategory.value === childCareYouthAndEducationCategoryString) {
+        const childCareYouthAndEducationDollarValue = renderAllCategoryValues(eligiblePrograms)[childCareYouthAndEducationCategoryString];
+        setTotalVisibleRowDollarValue(childCareYouthAndEducationDollarValue);
         return;
       }
 
@@ -248,7 +248,7 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
     });
   };
 
-  const preschoolProgramCategoryString = 'Child Care, Youth, and Education';
+  const childCareYouthAndEducationCategoryString = 'Child Care, Youth, and Education';
 
   const renderAllCategoryValues = (programs: Program[]) => {
     let childCareTotalEstVal = 0;
@@ -731,7 +731,7 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
               </span>
             </Toolbar>
             {currentCategory.defaultMessage ===
-              categories.find((cat) => cat.defaultMessage === preschoolProgramCategoryString)?.defaultMessage && (
+              categories.find((cat) => cat.defaultMessage === childCareYouthAndEducationCategoryString)?.defaultMessage && (
               <Typography variant="body2" className="child-care-helper-text">
                 <FormattedMessage
                   id="benefitCategories.childCareHelperText"

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -248,10 +248,14 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
   };
 
   const preschoolProgramCategoryString = 'Child Care, Youth, and Education';
-  const categoryValues = (programs: Program[]) => {
-    const preschoolPrograms = { numOfPreSchoolPrograms: 0, totalEstVal: 0 };
+
+  const renderAllCategoryValues = (programs: Program[]) => {
+    const childCareYouthEdPrograms = { childCareTotalEstVal: 0, youthAndEducationTotalEstVal: 0 };
     const categoryValues: { [key: string]: number } = {};
+
     for (let program of programs) {
+      const isPreschoolOrChildCareProgram = ['upk', 'dpp', 'chs', 'cccap'].includes(program.short_name);
+
       //add this category to the categoryValues dictionary if the key doesn't already exist
       if (categoryValues[program.category.default_message] === undefined) {
         categoryValues[program.category.default_message] = 0;
@@ -265,17 +269,21 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
         //we add that program's est value to its corresponding categoryValues key
         categoryValues[program.category.default_message] += program.estimated_value;
 
-        //if the program is a preschoolProgram, we also add it to the preschoolPrograms separately
-        if (program.category.default_message === preschoolProgramCategoryString) {
-          preschoolPrograms.numOfPreSchoolPrograms++;
-          preschoolPrograms.totalEstVal += program.estimated_value;
+        //if the program is a preschoolProgram, we also add it to the childCareYouthEdPrograms separately
+        if (isPreschoolOrChildCareProgram) {
+          childCareYouthEdPrograms.childCareTotalEstVal += program.estimated_value;
+        } else if (program.category.default_message === preschoolProgramCategoryString && isPreschoolOrChildCareProgram === false) {
+          childCareYouthEdPrograms.youthAndEducationTotalEstVal += program.estimated_value;
         }
       }
     }
 
-    if (preschoolPrograms.totalEstVal > 8640 && preschoolPrograms.numOfPreSchoolPrograms > 1) {
-      categoryValues[preschoolProgramCategoryString] = 8640;
+    if (childCareYouthEdPrograms.childCareTotalEstVal > 8640) {
+      childCareYouthEdPrograms.childCareTotalEstVal = 8640;
     }
+
+    categoryValues[preschoolProgramCategoryString] =
+      childCareYouthEdPrograms.childCareTotalEstVal + childCareYouthEdPrograms.youthAndEducationTotalEstVal;
 
     return categoryValues;
   };

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -157,8 +157,8 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
       }
     });
 
-    //used categoryValues(eligiblePrograms) instead of the real total to take into account the preschool category value cap at 8640
-    const allCategoriesAndValuesObjCappedForPreschool = categoryValues(eligiblePrograms);
+    //used renderAllCategoryValues(eligiblePrograms) instead of the real total to take into account the preschool category value cap at 8640
+    const allCategoriesAndValuesObjCappedForPreschool = renderAllCategoryValues(eligiblePrograms);
     const totalCashAndTaxCreditValues = Object.entries(allCategoriesAndValuesObjCappedForPreschool).reduce(
       (acc, categoryAndValueArr) => {
         const categoryName = categoryAndValueArr[0];
@@ -190,8 +190,9 @@ const Results = ({ handleTextFieldChange }: ResultsProps) => {
 
       //this is only to cap the totalVisibleRowDollarValue for preschool
       const typedFiltCategory = filt.category as GridFilterItem;
-      if (typedFiltCategory.value === preschoolProgramCategoryString && updatedTotalEligibleDollarValue > 8640) {
-        setTotalVisibleRowDollarValue(8640);
+      if (typedFiltCategory.value === preschoolProgramCategoryString) {
+        const preschoolCategoryDollarValue = renderAllCategoryValues(eligiblePrograms)[preschoolProgramCategoryString];
+        setTotalVisibleRowDollarValue(preschoolCategoryDollarValue);
         return;
       }
 


### PR DESCRIPTION
What (if anything) did you refactor?
- I refactored the `renderAllCategoryValues` and `useEffect` functions in `Results.tsx` by capping the preschool and child care total. 

Were there any issues that arose?
- No issues arose but what do we think about breaking out the Youth and Education Programs like the Pell Grant, My Spark and My Denver Card into their own category? This would help make capping much more straight forward instead of having this `const isPreschoolOrChildCareProgram = ['upk', 'dpp', 'chs', 'cccap'].includes(program.short_name)` hard coded condition that will need to be updated every time we add a new childcare or preschool program.


New `Child Care, Youth, and Education` category header on desktop:
<img width="1476" alt="Screenshot 2023-11-09 at 10 47 50 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/faa42a0e-03cb-48cd-897c-fb29b8673d3a">

New `Child Care, Youth, and Education` category header on mobile:
<img width="625" alt="Screenshot 2023-11-09 at 11 00 53 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/67d39cad-f02c-4142-a9a4-70bb18778162">
