### PR TITLE
Feat/211 language menu

### DIFF
--- a/src/Assets/languageOptions.tsx
+++ b/src/Assets/languageOptions.tsx
@@ -1,12 +1,12 @@
 export type Language = 'en-us' | 'es' | 'vi' | 'fr' | 'am' | 'so' | 'ru' | 'ne' | 'my' | 'zh';
 const languageOptions: Record<Language, string> = {
-  'en-us': 'English',
-  es: 'Español',
-  vi: 'Tiếng Việt',
-  fr: 'Français',
+  'en-us': 'ENGLISH',
+  es: 'ESPAÑOL',
+  vi: 'TIẾNG VIỆT',
+  fr: 'FRANÇAIS',
   am: 'አማርኛ',
-  so: 'Soomaali',
-  ru: 'Русский',
+  so: 'SOOMAALI',
+  ru: 'РУССКИЙ',
   ne: 'नेपाली',
   my: 'မြန်မာဘာသာစကား',
   zh: '汉语',

--- a/src/Components/Header/Header.css
+++ b/src/Components/Header/Header.css
@@ -49,7 +49,6 @@
   margin-right: 1.5rem;
   color: white;
   font-weight: 600;
-  text-transform: uppercase;
 }
 
 #select-language:focus-visible {

--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -2,7 +2,7 @@ import { AppBar, MenuItem, Select, Modal } from '@mui/material';
 import { useContext, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Context } from '../Wrapper/Wrapper.tsx';
-import globeIcon from '../../Assets/global-icon.png';
+import LanguageIcon from '@mui/icons-material/Language';
 import ShareIcon from '@mui/icons-material/Share';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import Share from '../Share/Share';
@@ -72,7 +72,7 @@ const Header = ({ handleTextfieldChange }) => {
             <img src={getReferrer('logoSource')} alt={getReferrer('logoAlt')} className={getReferrer('logoClass')} />
           </a>
           <div className="icon-wrapper">
-            <img src={globeIcon} alt="globe-icon" width={25}></img>
+            <LanguageIcon />
             <Select
               labelId="select-language-label"
               id="select-language"

--- a/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.css
+++ b/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.css
@@ -9,12 +9,16 @@
   font-size: 13px;
 }
 
+.twoOneOne-globe-icon {
+  color: var(--primary-color);
+}
+
 #twoOneOne-select-language {
   padding: 0;
   color: #005191;
   font-weight: 600;
   font-size: 0.79rem;
-  margin-left: 13px;
+  /* margin-left: 13px; */
 }
 
 #twoOneOne-nav-container {
@@ -56,9 +60,5 @@ button.hamburger-icon {
 @media (max-width: 500px) {
   .cobranded-logo {
     width: 75%;
-  }
-
-  div.twoOneOne-remove-leftMargin {
-    margin-left: 0;
   }
 }

--- a/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.css
+++ b/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.css
@@ -18,7 +18,7 @@
   color: #005191;
   font-weight: 600;
   font-size: 0.79rem;
-  /* margin-left: 13px; */
+  margin-right: 1.5rem;
 }
 
 #twoOneOne-nav-container {

--- a/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.css
+++ b/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.css
@@ -13,11 +13,18 @@
   color: var(--primary-color);
 }
 
+.twoOneOne-header-container {
+  background-color: #FFFFFF;
+  height: 5rem;
+  padding: 0 .5rem;
+  width: 100%;
+}
+
 #twoOneOne-select-language {
   padding: 0;
   color: #005191;
   font-weight: 600;
-  font-size: 0.79rem;
+  font-size: 13px;
   margin-right: 1.5rem;
 }
 
@@ -59,6 +66,6 @@ button.hamburger-icon {
 
 @media (max-width: 500px) {
   .cobranded-logo {
-    width: 75%;
+    width: 90%;
   }
 }

--- a/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
+++ b/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
@@ -170,7 +170,7 @@ const TwoOneOneHeader = ({ handleTextfieldChange }) => {
               {create211Links()}
             </Stack>
             <Stack direction="row" gap=".25rem" alignItems="center">
-              <LanguageIcon className='twoOneOne-globe-icon' />
+              <LanguageIcon className="twoOneOne-globe-icon" />
               <Select
                 labelId="select-language-label"
                 id="twoOneOne-select-language"
@@ -183,6 +183,7 @@ const TwoOneOneHeader = ({ handleTextfieldChange }) => {
                 open={isLanguageSelectOpen}
                 onOpen={handleOpenLanguage}
                 onClose={handleCloseLanguage}
+                sx={{ '& .MuiSvgIcon-root': { color: '#005191' } }}
               >
                 {createMenuItems(languageOptions)}
               </Select>

--- a/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
+++ b/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
@@ -68,11 +68,6 @@ const TwoOneOneHeader = ({ handleTextfieldChange }) => {
     setOpenMenu(!openMenu);
   };
 
-  const setRenderValue = () => {
-    const currentLocale = locale;
-    return currentLocale.slice(0, 2).toLocaleUpperCase();
-  };
-
   const create211Links = () => {
     const mappedLinks = twoOneOneLinks.map((link, index) => {
       return (
@@ -170,11 +165,12 @@ const TwoOneOneHeader = ({ handleTextfieldChange }) => {
               <img src={twoOneOneMFBLogo} alt="211 and myfriendben logo" className="cobranded-logo" />
             </a>
           </Box>
-          <Stack direction="row">
+          <Stack direction="row" gap="1rem">
             <Stack direction="row" gap="1rem" alignItems="center" className="twoOneOne-desktop-links">
               {create211Links()}
             </Stack>
-            <Stack direction="row" sx={{ marginLeft: '3rem' }} className="twoOneOne-remove-leftMargin">
+            <Stack direction="row" gap=".25rem" alignItems="center">
+              <LanguageIcon className='twoOneOne-globe-icon' />
               <Select
                 labelId="select-language-label"
                 id="twoOneOne-select-language"
@@ -187,9 +183,6 @@ const TwoOneOneHeader = ({ handleTextfieldChange }) => {
                 open={isLanguageSelectOpen}
                 onOpen={handleOpenLanguage}
                 onClose={handleCloseLanguage}
-                IconComponent={LanguageIcon}
-                renderValue={() => setRenderValue()}
-                sx={{ '& .MuiSvgIcon-root': { right: '1.25rem', color: '#005191' } }}
               >
                 {createMenuItems(languageOptions)}
               </Select>

--- a/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
+++ b/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
@@ -158,7 +158,7 @@ const TwoOneOneHeader = ({ handleTextfieldChange }) => {
 
   return (
     <nav>
-      <Paper elevation={4} sx={{ width: '100%', height: '50px', backgroundColor: '#FFFFFF' }} square={true}>
+      <Paper elevation={4} square={true} className='twoOneOne-header-container'>
         <AppBar position="sticky" id="twoOneOne-nav-container" elevation={0} sx={{ backgroundColor: '#FFFFFF' }}>
           <Box>
             <a href={`/step-1${queryString}`}>


### PR DESCRIPTION
What (if any) features are you implementing?
- Updated the language menu icon and text on the `Header` and `TwoOneOneHeader`.

What (if anything) did you refactor?
- I removed the image tag and replaced it with an MUI LanguageIcon.

Is there anything that you need from your teammate?
- Please review and let me know if you have any questions or concerns.

<img width="1725" alt="Screenshot 2024-01-02 at 3 35 56 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/94e89345-5742-49d2-86a8-a0761264800a">
<img width="467" alt="Screenshot 2024-01-02 at 3 35 47 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/2bd3d257-2f55-4c77-8d6a-fe67ece41ed1">
<img width="1728" alt="Screenshot 2024-01-02 at 3 34 45 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/e6243ec7-7beb-4ec8-9e27-8701569154e2">
<img width="514" alt="Screenshot 2024-01-02 at 3 34 34 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/0d5b4d06-6379-427e-8f3c-9504c3a3a984">
