### PR TITLE
Bug/Remove colon for income and expense questions

### DIFF
--- a/src/Components/ExpenseBlock/ExpenseQuestion.js
+++ b/src/Components/ExpenseBlock/ExpenseQuestion.js
@@ -96,15 +96,11 @@ const ExpenseQuestion = ({ expenseData, allExpensesData, setAllExpenses, deleteE
   };
 
   const getExpenseSourceLabel = (expenseSourceName) => {
-    return expenseSourceName ? (
-      <>
-        {'('}
-        {expenseOptions[expenseSourceName]}
-        {')?'}
-      </>
-    ) : (
-      '?'
-    );
+    if (expenseSourceName) {
+      return `(${expenseOptions[expenseSourceName]})?`;
+    }
+
+    return '?';
   };
 
   const textfieldProps = {
@@ -123,7 +119,7 @@ const ExpenseQuestion = ({ expenseData, allExpensesData, setAllExpenses, deleteE
         <p className="question-label">
           <FormattedMessage
             id="expenseBlock.createExpenseAmountTextfield-questionLabel"
-            defaultMessage="How much is this type of expense "
+            defaultMessage="How much is this type of expense"
           />
           {getExpenseSourceLabel(allExpensesData[index].expenseSourceName)}
         </p>

--- a/src/Components/ExpenseBlock/ExpenseQuestion.js
+++ b/src/Components/ExpenseBlock/ExpenseQuestion.js
@@ -96,7 +96,15 @@ const ExpenseQuestion = ({ expenseData, allExpensesData, setAllExpenses, deleteE
   };
 
   const getExpenseSourceLabel = (expenseSourceName) => {
-    return expenseOptions[expenseSourceName];
+    return expenseSourceName ? (
+      <>
+        {'('}
+        {expenseOptions[expenseSourceName]}
+        {')?'}
+      </>
+    ) : (
+      '?'
+    );
   };
 
   const textfieldProps = {
@@ -115,9 +123,9 @@ const ExpenseQuestion = ({ expenseData, allExpensesData, setAllExpenses, deleteE
         <p className="question-label">
           <FormattedMessage
             id="expenseBlock.createExpenseAmountTextfield-questionLabel"
-            defaultMessage="How much is this type of expense: "
+            defaultMessage="How much is this type of expense "
           />
-          {getExpenseSourceLabel(allExpensesData[index].expenseSourceName)}?
+          {getExpenseSourceLabel(allExpensesData[index].expenseSourceName)}
         </p>
         <div className="expense-block-textfield">
           <Textfield

--- a/src/Components/ExpenseBlock/ExpenseQuestion.js
+++ b/src/Components/ExpenseBlock/ExpenseQuestion.js
@@ -97,7 +97,7 @@ const ExpenseQuestion = ({ expenseData, allExpensesData, setAllExpenses, deleteE
 
   const getExpenseSourceLabel = (expenseSourceName) => {
     if (expenseSourceName) {
-      return `(${expenseOptions[expenseSourceName]})?`;
+      return <>({expenseOptions[expenseSourceName]})?</>;
     }
 
     return '?';

--- a/src/Components/IncomeBlock/IncomeQuestion.js
+++ b/src/Components/IncomeBlock/IncomeQuestion.js
@@ -59,7 +59,15 @@ const IncomeQuestion = ({
   });
 
   const getIncomeStreamNameLabel = (incomeStreamName) => {
-    return incomeOptions[incomeStreamName];
+    return incomeStreamName ? (
+      <>
+        {'('}
+        {incomeOptions[incomeStreamName]}
+        {')?'}
+      </>
+    ) : (
+      '?'
+    );
   };
 
   const createIncomeStreamsMenuItems = () => {
@@ -191,11 +199,11 @@ const IncomeQuestion = ({
 
   const createHoursWorkedTextField = (incomeStreamName, hoursWorked, index) => {
     let formattedMsgId = 'personIncomeBlock.createHoursWorkedTextfield-youQLabel';
-    let formattedMsgDefaultMsg = 'How many hours do you work per week: ';
+    let formattedMsgDefaultMsg = 'How many hours do you work per week ';
 
     if (page !== 1) {
       formattedMsgId = 'personIncomeBlock.createHoursWorkedTextfield-questionLabel';
-      formattedMsgDefaultMsg = 'How many hours do they work per week: ';
+      formattedMsgDefaultMsg = 'How many hours do they work per week ';
     }
 
     const hoursWorkedChange = (event, index) => {
@@ -228,7 +236,7 @@ const IncomeQuestion = ({
       <>
         <h2 className="question-label">
           <FormattedMessage id={formattedMsgId} defaultMessage={formattedMsgDefaultMsg} />
-          {getIncomeStreamNameLabel(allIncomeSources[index].incomeStreamName)}?
+          {getIncomeStreamNameLabel(allIncomeSources[index].incomeStreamName)}
         </h2>
         <div className="income-block-textfield">
           <Textfield
@@ -248,21 +256,21 @@ const IncomeQuestion = ({
 
     if (allIncomeSources[index].incomeFrequency === 'hourly') {
       let hourlyFormattedMsgId = 'incomeBlock.createIncomeAmountTextfield-hourly-questionLabel';
-      let hourlyFormattedMsgDefaultMsg = 'What is your hourly rate: ';
+      let hourlyFormattedMsgDefaultMsg = 'What is your hourly rate ';
 
       if (page !== 1) {
         hourlyFormattedMsgId = 'personIncomeBlock.createIncomeAmountTextfield-hourly-questionLabel';
-        hourlyFormattedMsgDefaultMsg = 'What is their hourly rate: ';
+        hourlyFormattedMsgDefaultMsg = 'What is their hourly rate ';
       }
 
       questionHeader = <FormattedMessage id={hourlyFormattedMsgId} defaultMessage={hourlyFormattedMsgDefaultMsg} />;
     } else {
       let payPeriodFormattedMsgId = 'incomeBlock.createIncomeAmountTextfield-questionLabel';
-      let payPeriodFormattedMsgDefaultMsg = 'How much do you receive each pay period for: ';
+      let payPeriodFormattedMsgDefaultMsg = 'How much do you receive each pay period for ';
 
       if (page !== 1) {
         payPeriodFormattedMsgId = 'personIncomeBlock.createIncomeAmountTextfield-questionLabel';
-        payPeriodFormattedMsgDefaultMsg = 'How much do they receive each pay period for: ';
+        payPeriodFormattedMsgDefaultMsg = 'How much do they receive each pay period for ';
       }
 
       questionHeader = (
@@ -286,7 +294,7 @@ const IncomeQuestion = ({
       <div>
         <h2 className="question-label">
           {questionHeader}
-          {getIncomeStreamNameLabel(allIncomeSources[index].incomeStreamName)}?
+          {getIncomeStreamNameLabel(allIncomeSources[index].incomeStreamName)}
         </h2>
         <div className="income-block-textfield">
           <Textfield
@@ -304,17 +312,17 @@ const IncomeQuestion = ({
 
   const createIncomeStreamFrequencyDropdownMenu = (incomeFrequency, index) => {
     let formattedMsgId = 'personIncomeBlock.createIncomeStreamFrequencyDropdownMenu-youQLabel';
-    let formattedMsgDefaultMsg = 'How often are you paid this income: ';
+    let formattedMsgDefaultMsg = 'How often are you paid this income ';
     if (page !== 1) {
       formattedMsgId = 'personIncomeBlock.createIncomeStreamFrequencyDropdownMenu-questionLabel';
-      formattedMsgDefaultMsg = 'How often are they paid this income: ';
+      formattedMsgDefaultMsg = 'How often are they paid this income ';
     }
 
     return (
       <div>
         <h2 className="question-label">
           <FormattedMessage id={formattedMsgId} defaultMessage={formattedMsgDefaultMsg} />
-          {getIncomeStreamNameLabel(allIncomeSources[index].incomeStreamName)}?
+          {getIncomeStreamNameLabel(allIncomeSources[index].incomeStreamName)}
         </h2>
         <FormControl sx={{ m: 1, minWidth: 120, maxWidth: '100%' }} error={incomeFrequencyErrorController.showError}>
           <InputLabel id="income-frequency-label">

--- a/src/Components/IncomeBlock/IncomeQuestion.js
+++ b/src/Components/IncomeBlock/IncomeQuestion.js
@@ -60,8 +60,9 @@ const IncomeQuestion = ({
 
   const getIncomeStreamNameLabel = (incomeStreamName) => {
     if (incomeStreamName) {
-      return `(${incomeOptions[incomeStreamName]})?`;
+      return <>({incomeOptions[incomeStreamName]})?</>;
     }
+
     return '?';
   };
 

--- a/src/Components/IncomeBlock/IncomeQuestion.js
+++ b/src/Components/IncomeBlock/IncomeQuestion.js
@@ -59,15 +59,10 @@ const IncomeQuestion = ({
   });
 
   const getIncomeStreamNameLabel = (incomeStreamName) => {
-    return incomeStreamName ? (
-      <>
-        {'('}
-        {incomeOptions[incomeStreamName]}
-        {')?'}
-      </>
-    ) : (
-      '?'
-    );
+    if (incomeStreamName) {
+      return `(${incomeOptions[incomeStreamName]})?`;
+    }
+    return '?';
   };
 
   const createIncomeStreamsMenuItems = () => {
@@ -199,11 +194,11 @@ const IncomeQuestion = ({
 
   const createHoursWorkedTextField = (incomeStreamName, hoursWorked, index) => {
     let formattedMsgId = 'personIncomeBlock.createHoursWorkedTextfield-youQLabel';
-    let formattedMsgDefaultMsg = 'How many hours do you work per week ';
+    let formattedMsgDefaultMsg = 'How many hours do you work per week';
 
     if (page !== 1) {
       formattedMsgId = 'personIncomeBlock.createHoursWorkedTextfield-questionLabel';
-      formattedMsgDefaultMsg = 'How many hours do they work per week ';
+      formattedMsgDefaultMsg = 'How many hours do they work per week';
     }
 
     const hoursWorkedChange = (event, index) => {
@@ -256,21 +251,21 @@ const IncomeQuestion = ({
 
     if (allIncomeSources[index].incomeFrequency === 'hourly') {
       let hourlyFormattedMsgId = 'incomeBlock.createIncomeAmountTextfield-hourly-questionLabel';
-      let hourlyFormattedMsgDefaultMsg = 'What is your hourly rate ';
+      let hourlyFormattedMsgDefaultMsg = 'What is your hourly rate';
 
       if (page !== 1) {
         hourlyFormattedMsgId = 'personIncomeBlock.createIncomeAmountTextfield-hourly-questionLabel';
-        hourlyFormattedMsgDefaultMsg = 'What is their hourly rate ';
+        hourlyFormattedMsgDefaultMsg = 'What is their hourly rate';
       }
 
       questionHeader = <FormattedMessage id={hourlyFormattedMsgId} defaultMessage={hourlyFormattedMsgDefaultMsg} />;
     } else {
       let payPeriodFormattedMsgId = 'incomeBlock.createIncomeAmountTextfield-questionLabel';
-      let payPeriodFormattedMsgDefaultMsg = 'How much do you receive before taxes each pay period for ';
+      let payPeriodFormattedMsgDefaultMsg = 'How much do you receive before taxes each pay period for';
 
       if (page !== 1) {
         payPeriodFormattedMsgId = 'personIncomeBlock.createIncomeAmountTextfield-questionLabel';
-        payPeriodFormattedMsgDefaultMsg = 'How much do they receive before taxes each pay period for ';
+        payPeriodFormattedMsgDefaultMsg = 'How much do they receive before taxes each pay period for';
       }
 
       questionHeader = (
@@ -312,10 +307,10 @@ const IncomeQuestion = ({
 
   const createIncomeStreamFrequencyDropdownMenu = (incomeFrequency, index) => {
     let formattedMsgId = 'personIncomeBlock.createIncomeStreamFrequencyDropdownMenu-youQLabel';
-    let formattedMsgDefaultMsg = 'How often are you paid this income ';
+    let formattedMsgDefaultMsg = 'How often are you paid this income';
     if (page !== 1) {
       formattedMsgId = 'personIncomeBlock.createIncomeStreamFrequencyDropdownMenu-questionLabel';
-      formattedMsgDefaultMsg = 'How often are they paid this income ';
+      formattedMsgDefaultMsg = 'How often are they paid this income';
     }
 
     return (


### PR DESCRIPTION
What (if any) features are you implementing?
- Removed the colon before the question mark for income and expense questions

Is there anything that you need from your teammate?
- Someone with the translation key has to help remove the colon from each languages as well. 

Screenshots
- Income you
><img width="703" alt="income_you" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/29790405/5aa98b00-6fa4-4e5c-ac93-193bfa2faadb">

- Incom they
><img width="705" alt="income_they" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/29790405/7755ac65-4192-4ddf-a82e-371e1230536b">

- Expense
><img width="696" alt="expense" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/29790405/1064b03e-6e77-4d92-a25f-852c1e9dc79c">

