### PR TITLE
Refactor/option card css

### DIFF
--- a/src/Components/OptionCardGroup/OptionCardGroup.css
+++ b/src/Components/OptionCardGroup/OptionCardGroup.css
@@ -49,7 +49,7 @@
   margin-bottom: 1.5rem;
 }
 
-@media (max-width: 610px) {
+@media (max-width: 38.125rem) {
   div.option-cards-container {
     gap: 0.938rem;
     margin-top: 1.5rem;

--- a/src/Components/OptionCardGroup/OptionCardGroup.css
+++ b/src/Components/OptionCardGroup/OptionCardGroup.css
@@ -49,7 +49,7 @@
   margin-bottom: 1.5rem;
 }
 
-@media (max-width: 420px) {
+@media (max-width: 545px) {
   div.option-cards-container {
     gap: 0.938rem;
     margin-top: 1.5rem;

--- a/src/Components/OptionCardGroup/OptionCardGroup.css
+++ b/src/Components/OptionCardGroup/OptionCardGroup.css
@@ -49,7 +49,7 @@
   margin-bottom: 1.5rem;
 }
 
-@media (max-width: 545px) {
+@media (max-width: 610px) {
   div.option-cards-container {
     gap: 0.938rem;
     margin-top: 1.5rem;


### PR DESCRIPTION
What (if any) features are you implementing?
- I increased the `max-width` for the media query to extend the option cards to a single card.

Media query at `610px` for main MFB site:
https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/93897803-b93e-448a-9a56-5be030a87c00

Media query at `610px` for 211 version of MFB site:
https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/f45e89ca-b24f-4e66-a488-76bd54f07849

