### PR TITLE
Edit Confirmation Navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,7 +216,9 @@ const App = () => {
     const isReferralQuestionWithOtherAndOtherSourceIsEmpty =
       questionName === 'referralSource' && formData.referralSource === 'other' && formData.otherSource === '';
     const isEmptyAssets = questionName === 'householdAssets' && formData.householdAssets < 0;
+    const isComingFromConfirmationPg = location.state ? location.state.routedFromConfirmationPg : false;
 
+    // console.log(location.state ?? location.state.routedFromConfirmationPg);
     if (!hasError) {
       if (isZipcodeQuestionAndCountyIsEmpty || isReferralQuestionWithOtherAndOtherSourceIsEmpty || isEmptyAssets) {
         return;
@@ -233,10 +235,12 @@ const App = () => {
         const updatedFormData = { ...formData, householdData: updatedHouseholdData };
         updateScreen(uuid, updatedFormData, locale);
         setFormData(updatedFormData);
-        navigate(`/${uuid}/step-${stepId + 1}/1`);
+        isComingFromConfirmationPg
+          ? navigate(`/${uuid}/confirm-information`)
+          : navigate(`/${uuid}/step-${stepId + 1}/1`);
       } else {
         updateScreen(uuid, formData, locale);
-        navigate(`/${uuid}/step-${stepId + 1}`);
+        isComingFromConfirmationPg ? navigate(`/${uuid}/confirm-information`) : navigate(`/${uuid}/step-${stepId + 1}`);
       }
     }
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import { BrandedFooter, BrandedHeader } from './Components/Referrer/Referrer.tsx
 import { useErrorController } from './Assets/validationFunctions.tsx';
 import dataLayerPush from './Assets/analytics.ts';
 import pageTitleTags, { StepName } from './Assets/pageTitleTags.ts';
-import { isCustomTypedLocationState } from './Types/FormData.js';
+import { isCustomTypedLocationState } from './Types/FormData.ts';
 import './App.css';
 LicenseInfo.setLicenseKey(process.env.REACT_APP_MUI_LICENSE_KEY + '=');
 
@@ -217,7 +217,9 @@ const App = () => {
     const isReferralQuestionWithOtherAndOtherSourceIsEmpty =
       questionName === 'referralSource' && formData.referralSource === 'other' && formData.otherSource === '';
     const isEmptyAssets = questionName === 'householdAssets' && formData.householdAssets < 0;
-    const isComingFromConfirmationPg = isCustomTypedLocationState(location.state) ? location.state.routedFromConfirmationPg : false;
+    const isComingFromConfirmationPg = isCustomTypedLocationState(location.state)
+      ? location.state.routedFromConfirmationPg
+      : false;
 
     if (!hasError) {
       if (isZipcodeQuestionAndCountyIsEmpty || isReferralQuestionWithOtherAndOtherSourceIsEmpty || isEmptyAssets) {
@@ -253,7 +255,9 @@ const App = () => {
   };
 
   const handleExpenseSourcesSubmit = (validatedExpenseSources: Expense[], stepId: number, uuid: string) => {
-    const isComingFromConfirmationPg = isCustomTypedLocationState(location.state) ? location.state.routedFromConfirmationPg : false;
+    const isComingFromConfirmationPg = isCustomTypedLocationState(location.state)
+      ? location.state.routedFromConfirmationPg
+      : false;
     const updatedFormData = { ...formData, expenses: validatedExpenseSources };
     updateScreen(uuid, updatedFormData, locale);
     setFormData(updatedFormData);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { BrandedFooter, BrandedHeader } from './Components/Referrer/Referrer.tsx
 import { useErrorController } from './Assets/validationFunctions.tsx';
 import dataLayerPush from './Assets/analytics.ts';
 import pageTitleTags, { StepName } from './Assets/pageTitleTags.ts';
+import { isCustomTypedLocationState } from './Types/FormData.js';
 import './App.css';
 LicenseInfo.setLicenseKey(process.env.REACT_APP_MUI_LICENSE_KEY + '=');
 
@@ -216,9 +217,8 @@ const App = () => {
     const isReferralQuestionWithOtherAndOtherSourceIsEmpty =
       questionName === 'referralSource' && formData.referralSource === 'other' && formData.otherSource === '';
     const isEmptyAssets = questionName === 'householdAssets' && formData.householdAssets < 0;
-    const isComingFromConfirmationPg = location.state ? location.state.routedFromConfirmationPg : false;
+    const isComingFromConfirmationPg = isCustomTypedLocationState(location.state) ? location.state.routedFromConfirmationPg : false;
 
-    // console.log(location.state ?? location.state.routedFromConfirmationPg);
     if (!hasError) {
       if (isZipcodeQuestionAndCountyIsEmpty || isReferralQuestionWithOtherAndOtherSourceIsEmpty || isEmptyAssets) {
         return;
@@ -253,10 +253,11 @@ const App = () => {
   };
 
   const handleExpenseSourcesSubmit = (validatedExpenseSources: Expense[], stepId: number, uuid: string) => {
+    const isComingFromConfirmationPg = isCustomTypedLocationState(location.state) ? location.state.routedFromConfirmationPg : false;
     const updatedFormData = { ...formData, expenses: validatedExpenseSources };
     updateScreen(uuid, updatedFormData, locale);
     setFormData(updatedFormData);
-    navigate(`/${uuid}/step-${stepId + 1}`);
+    isComingFromConfirmationPg ? navigate(`/${uuid}/confirm-information`) : navigate(`/${uuid}/step-${stepId + 1}`);
   };
 
   const handleHouseholdDataSubmit = (memberData: HouseholdData, stepId: number, uuid: string) => {
@@ -265,7 +266,6 @@ const App = () => {
     const updatedFormData = { ...formData, householdData: updatedMembers };
     updateScreen(uuid, updatedFormData, locale);
     setFormData(updatedFormData);
-    navigate(`/${uuid}/step-${stepId + 1}`);
   };
 
   if (pageIsLoading) {

--- a/src/Components/Confirmation/Confirmation.js
+++ b/src/Components/Confirmation/Confirmation.js
@@ -37,6 +37,7 @@ const Confirmation = () => {
   const { uuid } = useParams();
   const navigate = useNavigate();
   const intl = useIntl();
+  const locationState = { state: { routedFromConfirmationPg: true } };
 
   const getQuestionUrl = (name) => {
     const stepNumber = getStepNumber(name, formData.immutableReferrer);
@@ -101,7 +102,7 @@ const Confirmation = () => {
             <button
               aria-label="edit household member"
               onClick={() =>
-                navigate(getQuestionUrl('householdData') + `/${i + 1}`, { state: { routedFromConfirmationPg: true } })
+                navigate(getQuestionUrl('householdData') + `/${i + 1}`, locationState)
               }
             >
               <Edit className="edit-button" alt="edit-icon" />
@@ -152,7 +153,7 @@ const Confirmation = () => {
         <Grid item xs={2} display="flex" justifyContent="flex-end">
           <button
             aria-label="edit expenses"
-            onClick={() => navigate(getQuestionUrl('hasExpenses'), { state: { routedFromConfirmationPg: true } })}
+            onClick={() => navigate(getQuestionUrl('hasExpenses'), locationState)}
           >
             <Edit className="edit-button" alt="edit-icon" />
           </button>
@@ -319,7 +320,7 @@ const Confirmation = () => {
         <Grid item xs={2} display="flex" justifyContent="flex-end">
           <button
             aria-label="edit household assets"
-            onClick={() => navigate(getQuestionUrl('householdAssets'), { state: { routedFromConfirmationPg: true } })}
+            onClick={() => navigate(getQuestionUrl('householdAssets'), locationState)}
           >
             <Edit className="edit-button" alt="edit-icon" />
           </button>
@@ -355,7 +356,7 @@ const Confirmation = () => {
         <Grid item xs={2} display="flex" justifyContent="flex-end">
           <button
             aria-label="edit zipcode"
-            onClick={() => navigate(getQuestionUrl('zipcode'), { state: { routedFromConfirmationPg: true } })}
+            onClick={() => navigate(getQuestionUrl('zipcode'), locationState)}
           >
             <Edit className="edit-button" alt="edit-icon" />
           </button>
@@ -391,7 +392,7 @@ const Confirmation = () => {
           <Grid item xs={2} display="flex" justifyContent="flex-end">
             <button
               aria-label="edit referral source"
-              onClick={() => navigate(getQuestionUrl('referralSource'), { state: { routedFromConfirmationPg: true } })}
+              onClick={() => navigate(getQuestionUrl('referralSource'), locationState)}
             >
               <Edit className="edit-button" alt="edit-icon" />
             </button>
@@ -579,7 +580,7 @@ const Confirmation = () => {
         <Grid item xs={2} display="flex" justifyContent="flex-end">
           <button
             aria-label={ariaLabel}
-            onClick={() => navigate(linkTo, { state: { routedFromConfirmationPg: true } })}
+            onClick={() => navigate(linkTo, locationState)}
           >
             <Edit className="edit-button" alt="edit-icon" />
           </button>

--- a/src/Components/Confirmation/Confirmation.js
+++ b/src/Components/Confirmation/Confirmation.js
@@ -100,7 +100,7 @@ const Confirmation = () => {
           <Grid item xs={2} display="flex" justifyContent="flex-end">
             <button
               aria-label="edit household member"
-              onClick={() => navigate(getQuestionUrl('householdData') + `/${i + 1}`)}
+              onClick={() => navigate(getQuestionUrl('householdData') + `/${i + 1}`, { state: { routedFromConfirmationPg: true } })}
             >
               <Edit className="edit-button" alt="edit-icon" />
             </button>
@@ -148,7 +148,10 @@ const Confirmation = () => {
           )}
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button aria-label="edit expenses" onClick={() => navigate(getQuestionUrl('hasExpenses'))}>
+          <button
+            aria-label="edit expenses"
+            onClick={() => navigate(getQuestionUrl('hasExpenses'), { state: { routedFromConfirmationPg: true } })}
+          >
             <Edit className="edit-button" alt="edit-icon" />
           </button>
         </Grid>
@@ -279,7 +282,10 @@ const Confirmation = () => {
           </article>
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button aria-label="edit household size" onClick={() => navigate(linkTo)}>
+          <button
+            aria-label="edit household size"
+            onClick={() => navigate(linkTo, { state: { routedFromConfirmationPg: true } })}
+          >
             <Edit className="edit-button" alt="edit-icon" />
           </button>
         </Grid>
@@ -312,7 +318,10 @@ const Confirmation = () => {
           </article>
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button aria-label="edit household assets" onClick={() => navigate(getQuestionUrl('householdAssets'))}>
+          <button
+            aria-label="edit household assets"
+            onClick={() => navigate(getQuestionUrl('householdAssets'), { state: { routedFromConfirmationPg: true } })}
+          >
             <Edit className="edit-button" alt="edit-icon" />
           </button>
         </Grid>
@@ -345,7 +354,10 @@ const Confirmation = () => {
           </p>
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button aria-label="edit zipcode" onClick={() => navigate(getQuestionUrl('zipcode'))}>
+          <button
+            aria-label="edit zipcode"
+            onClick={() => navigate(getQuestionUrl('zipcode'), { state: { routedFromConfirmationPg: true } })}
+          >
             <Edit className="edit-button" alt="edit-icon" />
           </button>
         </Grid>
@@ -378,7 +390,10 @@ const Confirmation = () => {
             <article className="section-p">{finalReferralSource}</article>
           </Grid>
           <Grid item xs={2} display="flex" justifyContent="flex-end">
-            <button aria-label="edit referral source" onClick={() => navigate(getQuestionUrl('referralSource'))}>
+            <button
+              aria-label="edit referral source"
+              onClick={() => navigate(getQuestionUrl('referralSource'), { state: { routedFromConfirmationPg: true } })}
+            >
               <Edit className="edit-button" alt="edit-icon" />
             </button>
           </Grid>
@@ -563,7 +578,10 @@ const Confirmation = () => {
           )}
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button aria-label={ariaLabel} onClick={() => navigate(linkTo)}>
+          <button
+            aria-label={ariaLabel}
+            onClick={() => navigate(linkTo, { state: { routedFromConfirmationPg: true } })}
+          >
             <Edit className="edit-button" alt="edit-icon" />
           </button>
         </Grid>

--- a/src/Components/Confirmation/Confirmation.js
+++ b/src/Components/Confirmation/Confirmation.js
@@ -284,7 +284,7 @@ const Confirmation = () => {
         <Grid item xs={2} display="flex" justifyContent="flex-end">
           <button
             aria-label="edit household size"
-            onClick={() => navigate(linkTo, { state: { routedFromConfirmationPg: true } })}
+            onClick={() => navigate(linkTo)}
           >
             <Edit className="edit-button" alt="edit-icon" />
           </button>

--- a/src/Components/Confirmation/Confirmation.js
+++ b/src/Components/Confirmation/Confirmation.js
@@ -100,7 +100,9 @@ const Confirmation = () => {
           <Grid item xs={2} display="flex" justifyContent="flex-end">
             <button
               aria-label="edit household member"
-              onClick={() => navigate(getQuestionUrl('householdData') + `/${i + 1}`, { state: { routedFromConfirmationPg: true } })}
+              onClick={() =>
+                navigate(getQuestionUrl('householdData') + `/${i + 1}`, { state: { routedFromConfirmationPg: true } })
+              }
             >
               <Edit className="edit-button" alt="edit-icon" />
             </button>
@@ -282,10 +284,7 @@ const Confirmation = () => {
           </article>
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button
-            aria-label="edit household size"
-            onClick={() => navigate(linkTo)}
-          >
+          <button aria-label="edit household size" onClick={() => navigate(linkTo)}>
             <Edit className="edit-button" alt="edit-icon" />
           </button>
         </Grid>

--- a/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
+++ b/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { Box, IconButton, Stack } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
@@ -23,6 +23,7 @@ import {
 } from '../../Assets/validationFunctions.tsx';
 import { getStepNumber } from '../../Assets/stepDirectory';
 import { Context } from '../Wrapper/Wrapper.tsx';
+import { isCustomTypedLocationState } from '../../Types/FormData.ts';
 import './HouseholdDataBlock.css';
 
 const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
@@ -33,6 +34,7 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
   page = parseInt(page);
   const step = getStepNumber('householdData');
   const navigate = useNavigate();
+  const location = useLocation();
   const setPage = (page) => {
     navigate(`/${uuid}/step-${step}/${page}`);
   };
@@ -389,13 +391,20 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
   };
 
   const handleContinueSubmit = (event, validateInputFunction, inputToBeValidated, stepId, questionName, uuid) => {
+    const isComingFromConfirmationPg = isCustomTypedLocationState(location.state)
+      ? location.state.routedFromConfirmationPg
+      : false;
+
     event.preventDefault();
     setSubmittedCount(submittedCount + 1);
 
     const validPersonData = personDataIsValid(memberData);
     const lastHouseholdMember = page >= remainingHHMNumber;
 
-    if (validPersonData && lastHouseholdMember) {
+    if (validPersonData && isComingFromConfirmationPg) {
+      handleHouseholdDataSubmit(memberData, page - 1, uuid);
+      navigate(`/${uuid}/confirm-information`);
+    } else if (validPersonData && lastHouseholdMember) {
       handleHouseholdDataSubmit(memberData, page - 1, uuid);
       navigate(`/${uuid}/step-${step + 1}`);
     } else if (validPersonData) {

--- a/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
+++ b/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
@@ -82,6 +82,16 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
     setMemberData(updatedMemberData);
   }, [memberData.hasIncome]);
 
+  useEffect(() => {
+    //this useEffect solves for the unlikely scenario that the page number is greater than the HHSize or NaN,
+    //it routes the user back to the last valid HHM
+    const lastMemberPage = Math.min(formData.householdData.length + 1, formData.householdSize);
+    if (isNaN(page) || page < 1 || page > lastMemberPage) {
+      navigate(`/${uuid}/step-${step}/${lastMemberPage}`, { replace: true });
+      return;
+    }
+  }, []);
+
   const createFMInputLabel = (personIndex) => {
     if (personIndex === 1) {
       return <FormattedMessage id="householdDataBlock.createFMInputLabel-headOfHH" defaultMessage="Your Age" />;

--- a/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
+++ b/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
@@ -82,14 +82,6 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
     setMemberData(updatedMemberData);
   }, [memberData.hasIncome]);
 
-  useEffect(() => {
-    const lastMemberPage = Math.min(formData.householdData.length + 1, formData.householdSize);
-    if (isNaN(page) || page < 1 || page >= lastMemberPage) {
-      navigate(`/${uuid}/step-${step}/${lastMemberPage}`, { replace: true });
-      return;
-    }
-  }, []);
-
   const createFMInputLabel = (personIndex) => {
     if (personIndex === 1) {
       return <FormattedMessage id="householdDataBlock.createFMInputLabel-headOfHH" defaultMessage="Your Age" />;

--- a/src/Types/FormData.ts
+++ b/src/Types/FormData.ts
@@ -115,3 +115,9 @@ export interface Conditions {
   disabled: boolean;
   longTermDisability: boolean;
 }
+
+  export const isCustomTypedLocationState = (
+    locationState: unknown,
+  ): locationState is { routedFromConfirmationPg: boolean } => {
+    return typeof locationState === 'object' && locationState !== null && 'routedFromConfirmationPg' in locationState;
+  };

--- a/src/Types/FormData.ts
+++ b/src/Types/FormData.ts
@@ -116,8 +116,8 @@ export interface Conditions {
   longTermDisability: boolean;
 }
 
-  export const isCustomTypedLocationState = (
-    locationState: unknown,
-  ): locationState is { routedFromConfirmationPg: boolean } => {
-    return typeof locationState === 'object' && locationState !== null && 'routedFromConfirmationPg' in locationState;
-  };
+export const isCustomTypedLocationState = (
+  locationState: unknown,
+): locationState is { routedFromConfirmationPg: boolean } => {
+  return typeof locationState === 'object' && locationState !== null && 'routedFromConfirmationPg' in locationState;
+};


### PR DESCRIPTION
What (if any) features are you implementing?
- When a user clicks on any of the `Edit` links in the `Confirmation` page they are routed to that page so that they can make any necessary changes and then when they click on the `Continue` button they are routed back to the `Confirmation` page instead of the next step (i.e. going through the entire form again).

What (if anything) did you refactor?
- I removed a `useEffect` function in the `HouseholdDataBlock` that was preventing the last household member from being routed back to the `Confirmation` page after they completed their edits.

Is there anything that you need from your teammate?
- Please review and let me know if you have any questions or concerns.

I've added a link to the demo below:
https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/13d941fd-165d-43af-ac03-635f89444581


