### PR TITLE
Refactor/income expense dd menus

### DIFF
--- a/src/Assets/expenseOptions.tsx
+++ b/src/Assets/expenseOptions.tsx
@@ -1,21 +1,21 @@
 import { FormattedMessage } from 'react-intl';
 
 const expenseOptions = {
+  rent: <FormattedMessage id="expenseOptions.rent" defaultMessage="Rent" />,
+  telephone: <FormattedMessage id="expenseOptions.telephone" defaultMessage="Telephone" />,
+  internet: <FormattedMessage id="expenseOptions.internet" defaultMessage="Internet" />,
+  auto: <FormattedMessage id="expenseOptions.auto" defaultMessage="Auto Insurance Premium &/or Payment" />,
+  otherUtilities: <FormattedMessage id="expenseOptions.otherUtilities" defaultMessage="Other Utilities" />,
+  heating: <FormattedMessage id="expenseOptions.heating" defaultMessage="Heating" />,
+  creditCard: <FormattedMessage id="expenseOptions.creditCard" defaultMessage="Credit Card Debt" />,
+  mortgage: <FormattedMessage id="expenseOptions.mortgage" defaultMessage="Mortgage" />,
+  medical: <FormattedMessage id="expenseOptions.medical" defaultMessage="Medical Insurance Premium &/or Bills" />,
+  personalLoan: <FormattedMessage id="expenseOptions.personalLoan" defaultMessage="Personal Loan" />,
+  studentLoans: <FormattedMessage id="expenseOptions.studentLoans" defaultMessage="Student Loans" />,
+  cooling: <FormattedMessage id="expenseOptions.cooling" defaultMessage="Cooling" />,
   childCare: <FormattedMessage id="expenseOptions.childCare" defaultMessage="Child Care" />,
   childSupport: <FormattedMessage id="expenseOptions.childSupport" defaultMessage="Child Support (Paid)" />,
   dependentCare: <FormattedMessage id="expenseOptions.dependentCare" defaultMessage="Dependent Care" />,
-  rent: <FormattedMessage id="expenseOptions.rent" defaultMessage="Rent" />,
-  mortgage: <FormattedMessage id="expenseOptions.mortgage" defaultMessage="Mortgage" />,
-  heating: <FormattedMessage id="expenseOptions.heating" defaultMessage="Heating" />,
-  cooling: <FormattedMessage id="expenseOptions.cooling" defaultMessage="Cooling" />,
-  telephone: <FormattedMessage id="expenseOptions.telephone" defaultMessage="Telephone" />,
-  internet: <FormattedMessage id="expenseOptions.internet" defaultMessage="Internet" />,
-  otherUtilities: <FormattedMessage id="expenseOptions.otherUtilities" defaultMessage="Other Utilities" />,
-  auto: <FormattedMessage id="expenseOptions.auto" defaultMessage="Auto Insurance Premium &/or Payment" />,
-  medical: <FormattedMessage id="expenseOptions.medical" defaultMessage="Medical Insurance Premium &/or Bills" />,
-  studentLoans: <FormattedMessage id="expenseOptions.studentLoans" defaultMessage="Student Loans" />,
-  creditCard: <FormattedMessage id="expenseOptions.creditCard" defaultMessage="Credit Card Debt" />,
-  personalLoan: <FormattedMessage id="expenseOptions.personalLoan" defaultMessage="Personal Loan" />,
 };
 
 export default expenseOptions;

--- a/src/Assets/incomeOptions.tsx
+++ b/src/Assets/incomeOptions.tsx
@@ -8,33 +8,42 @@ const incomeOptions = {
       defaultMessage="Income from freelance, independent contractor, or self-employment work"
     />
   ),
-  unemployment: <FormattedMessage id="incomeOptions.unemployment" defaultMessage="Unemployment Benefits" />,
-  cashAssistance: <FormattedMessage id="incomeOptions.cashAssistance" defaultMessage="Cash Assistance Grant" />,
-  childSupport: <FormattedMessage id="incomeOptions.childSupport" defaultMessage="Child Support (Received)" />,
-  sSI: <FormattedMessage id="incomeOptions.sSI" defaultMessage="Supplemental Security Income (SSI)" />,
   sSDisability: (
     <FormattedMessage id="incomeOptions.sSDisability" defaultMessage="Social Security Disability Benefits" />
   ),
+  sSRetirement: (
+    <FormattedMessage id="incomeOptions.sSRetirement" defaultMessage="Social Security Retirement Benefits" />
+  ),
+  sSI: <FormattedMessage id="incomeOptions.sSI" defaultMessage="Supplemental Security Income (SSI)" />,
+  childSupport: <FormattedMessage id="incomeOptions.childSupport" defaultMessage="Child Support (Received)" />,
+  pension: <FormattedMessage id="incomeOptions.pension" defaultMessage="Military, Government, or Private Pension" />,
+  veteran: <FormattedMessage id="incomeOptions.veteran" defaultMessage="Veteran's Pension or Benefits" />,
   sSSurvivor: (
     <FormattedMessage
       id="incomeOptions.sSSurvivor"
       defaultMessage="Social Security Survivor's Benefits (Widow/Widower)"
     />
   ),
-  sSRetirement: (
-    <FormattedMessage id="incomeOptions.sSRetirement" defaultMessage="Social Security Retirement Benefits" />
-  ),
+  unemployment: <FormattedMessage id="incomeOptions.unemployment" defaultMessage="Unemployment Benefits" />,
   sSDependent: (
     <FormattedMessage
       id="incomeOptions.sSDependent"
       defaultMessage="Social Security Dependent Benefits (retirement, disability, or survivors)"
     />
   ),
+  cashAssistance: <FormattedMessage id="incomeOptions.cashAssistance" defaultMessage="Cash Assistance Grant" />,
+  gifts: <FormattedMessage id="incomeOptions.gifts" defaultMessage="Gifts/Contributions (Received)" />,
+  investment: (
+    <FormattedMessage
+      id="incomeOptions.investment"
+      defaultMessage="Investment Income (interest, dividends, and profit from selling stocks)"
+    />
+  ),
   cOSDisability: (
     <FormattedMessage id="incomeOptions.cOSDisability" defaultMessage="Colorado State Disability Benefits" />
   ),
-  veteran: <FormattedMessage id="incomeOptions.veteran" defaultMessage="Veteran's Pension or Benefits" />,
-  pension: <FormattedMessage id="incomeOptions.pension" defaultMessage="Military, Government, or Private Pension" />,
+  rental: <FormattedMessage id="incomeOptions.rental" defaultMessage="Rental Income" />,
+  alimony: <FormattedMessage id="incomeOptions.alimony" defaultMessage="Alimony (Received)" />,
   deferredComp: (
     <FormattedMessage
       id="incomeOptions.deferredComp"
@@ -42,16 +51,7 @@ const incomeOptions = {
     />
   ),
   workersComp: <FormattedMessage id="incomeOptions.workersComp" defaultMessage="Worker's Compensation" />,
-  alimony: <FormattedMessage id="incomeOptions.alimony" defaultMessage="Alimony (Received)" />,
   boarder: <FormattedMessage id="incomeOptions.boarder" defaultMessage="Boarder or Lodger" />,
-  gifts: <FormattedMessage id="incomeOptions.gifts" defaultMessage="Gifts/Contributions (Received)" />,
-  rental: <FormattedMessage id="incomeOptions.rental" defaultMessage="Rental Income" />,
-  investment: (
-    <FormattedMessage
-      id="incomeOptions.investment"
-      defaultMessage="Investment Income (interest, dividends, and profit from selling stocks)"
-    />
-  ),
 };
 
 export default incomeOptions;


### PR DESCRIPTION
What (if anything) did you refactor?
- I reordered the `incomeOptions` and `expenseOptions` based on the data that was shown on the MFB Dashboard.

Is there anything that you need from your teammate?
- Please review and let me know if you have any questions or concerns?

Income Options:
<img width="1728" alt="Screenshot 2024-02-07 at 2 36 09 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/6f6eff63-7766-4ce5-86dd-9ed39f715882">

Expense Options:
<img width="1728" alt="Screenshot 2024-02-07 at 2 38 30 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/a27649f7-5292-4067-a67d-fda42ac1d7f8">

