### PR TITLE
Decreased Results Tabs on Mobile 

### DIFF
--- a/src/Components/Results/Results.css
+++ b/src/Components/Results/Results.css
@@ -19,7 +19,7 @@
   display: block;
   text-align: center;
   text-transform: uppercase;
-  padding: 1rem;
+  padding: 0.5rem;
   text-decoration: none;
   background-color: #e6e7e8;
   color: var(--primary-color);
@@ -271,6 +271,10 @@
     font-family: 'Open Sans', sans-serif;
     font-weight: 400;
     color: var(--primary-color);
+  }
+
+  .results-tab a {
+    padding: 1rem;
   }
 
   .result-program-container {

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -12,8 +12,6 @@ import Needs from './Needs/Needs';
 import Programs from './Programs/Programs';
 import ProgramPage from './ProgramPage/ProgramPage';
 import ResultsTabs from './Tabs/Tabs';
-import MoreHelp from './MoreHelp/MoreHelp';
-import NavigatorPage from './NavigatorPage/NavigatorPage';
 import { CitizenLabels } from '../../Assets/citizenshipFilterFormControlLabels';
 import dataLayerPush from '../../Assets/analytics';
 import HelpButton from './211Button/211Button';

--- a/src/Components/Results/ResultsError/ResultsError.tsx
+++ b/src/Components/Results/ResultsError/ResultsError.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@mui/material';
-import ErrorIcon from '../../../Assets/error-icon.svg';
+import ErrorIcon from '../../../Assets/icons/error-icon.svg';
 import { useParams, useNavigate } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import './ResultsError.css';


### PR DESCRIPTION
What (if anything) did you refactor?
- Result tabs on mobile padding reduced by 50%
Were there any issues that arose?
- Fixed an import path error and cleaned up unused imports.

<img width="387" alt="Screenshot 2024-02-14 at 1 25 10 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/7133950/e0a35e7a-079e-4b39-bbfb-33259e1ebdeb">
