### PR TITLE
Refactor/results padding

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
   "plugins": ["react"],
   "rules": {
     "react/react-in-jsx-scope": "off",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "react/jsx-no-target-blank": "off"
   }
 }

--- a/src/Components/Confirmation/Confirmation.js
+++ b/src/Components/Confirmation/Confirmation.js
@@ -101,9 +101,7 @@ const Confirmation = () => {
           <Grid item xs={2} display="flex" justifyContent="flex-end">
             <button
               aria-label="edit household member"
-              onClick={() =>
-                navigate(getQuestionUrl('householdData') + `/${i + 1}`, locationState)
-              }
+              onClick={() => navigate(getQuestionUrl('householdData') + `/${i + 1}`, locationState)}
             >
               <Edit className="edit-button" alt="edit-icon" />
             </button>
@@ -151,10 +149,7 @@ const Confirmation = () => {
           )}
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button
-            aria-label="edit expenses"
-            onClick={() => navigate(getQuestionUrl('hasExpenses'), locationState)}
-          >
+          <button aria-label="edit expenses" onClick={() => navigate(getQuestionUrl('hasExpenses'), locationState)}>
             <Edit className="edit-button" alt="edit-icon" />
           </button>
         </Grid>
@@ -354,10 +349,7 @@ const Confirmation = () => {
           </p>
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button
-            aria-label="edit zipcode"
-            onClick={() => navigate(getQuestionUrl('zipcode'), locationState)}
-          >
+          <button aria-label="edit zipcode" onClick={() => navigate(getQuestionUrl('zipcode'), locationState)}>
             <Edit className="edit-button" alt="edit-icon" />
           </button>
         </Grid>
@@ -578,10 +570,7 @@ const Confirmation = () => {
           )}
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button
-            aria-label={ariaLabel}
-            onClick={() => navigate(linkTo, locationState)}
-          >
+          <button aria-label={ariaLabel} onClick={() => navigate(linkTo, locationState)}>
             <Edit className="edit-button" alt="edit-icon" />
           </button>
         </Grid>

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -106,11 +106,7 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
           id="disclaimer-label"
           defaultMessage="By proceeding, you confirm that you have read and agree to the "
         />
-        <Link
-          href={getLinksForCheckbox().privacyPolicyLink}
-          target="_blank"
-          sx={{ color: theme.secondaryColor }}
-        >
+        <Link href={getLinksForCheckbox().privacyPolicyLink} target="_blank" sx={{ color: theme.secondaryColor }}>
           <FormattedMessage id="landingPage-policyText" defaultMessage="Privacy Policy" />
         </Link>
         <FormattedMessage id="landingPage-and-text" defaultMessage=" and " />

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -109,7 +109,6 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
         <Link
           href={getLinksForCheckbox().privacyPolicyLink}
           target="_blank"
-          rel="noopener noreferrer"
           sx={{ color: theme.secondaryColor }}
         >
           <FormattedMessage id="landingPage-policyText" defaultMessage="Privacy Policy" />
@@ -118,7 +117,6 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
         <Link
           href={getLinksForCheckbox().addTermsConsentToContact}
           target="_blank"
-          rel="noopener noreferrer"
           sx={{ color: theme.secondaryColor }}
         >
           <FormattedMessage id="landingPage-additionalTerms" defaultMessage="Additional Terms & Consent to Contact" />
@@ -159,7 +157,6 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
                 style={{ color: theme.secondaryColor }}
                 href="https://cdhs.colorado.gov/public-charge-rule-and-colorado-immigrants#:~:text=About%20public%20charge&text=The%20test%20looks%20at%20whether,affidavit%20of%20support%20or%20contract."
                 target="_blank"
-                rel="noreferrer"
                 onClick={() => {
                   dataLayerPush({
                     event: 'public_charge',

--- a/src/Components/NoResultsTable/NoResultsTable.tsx
+++ b/src/Components/NoResultsTable/NoResultsTable.tsx
@@ -21,7 +21,6 @@ const NoResultsTable = () => {
         <a
           className="ineligibility-link navigator-info"
           target="_blank"
-          rel="noreferrer"
           href={getReferrer('twoOneOneLink')}
         >
           2-1-1 Colorado

--- a/src/Components/NoResultsTable/NoResultsTable.tsx
+++ b/src/Components/NoResultsTable/NoResultsTable.tsx
@@ -18,11 +18,7 @@ const NoResultsTable = () => {
       </p>
       <p className="noResults-p">
         <FormattedMessage id="noResults.p-Two" defaultMessage="For additional resources, visit " />
-        <a
-          className="ineligibility-link navigator-info"
-          target="_blank"
-          href={getReferrer('twoOneOneLink')}
-        >
+        <a className="ineligibility-link navigator-info" target="_blank" href={getReferrer('twoOneOneLink')}>
           2-1-1 Colorado
         </a>
         <FormattedMessage

--- a/src/Components/OptionCardGroup/OptionCardGroup.css
+++ b/src/Components/OptionCardGroup/OptionCardGroup.css
@@ -25,8 +25,7 @@
   width: 4.375rem;
 }
 
-.option-card-icon > path,
-.option-card-icon > g > path {
+.option-card-icon path {
   fill: var(--icon-color);
 }
 

--- a/src/Components/Results/211Button/211Button.css
+++ b/src/Components/Results/211Button/211Button.css
@@ -9,7 +9,7 @@
   text-decoration: none;
   padding: 0.5rem 2rem;
   align-self: center;
-  margin-top: .5rem;
+  margin-top: 0.5rem;
 }
 
 .button211:hover {

--- a/src/Components/Results/211Button/211Button.css
+++ b/src/Components/Results/211Button/211Button.css
@@ -2,17 +2,14 @@
   display: flex;
   background-color: var(--primary-color);
   border-radius: 1.8rem;
-  text-align: center;
   color: white;
-  align-items: center;
-  line-height: normal;
   font-family: 'Roboto Slab', serif;
   font-weight: 700;
   font-size: 1.25rem;
   text-decoration: none;
   padding: 0.5rem 2rem;
-  margin: auto;
-  width: fit-content;
+  align-self: center;
+  margin-top: .5rem;
 }
 
 .button211:hover {
@@ -29,6 +26,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  margin-bottom: 3rem;
 }
 
 .help-text-for-211-button-font {

--- a/src/Components/Results/211Button/211Button.tsx
+++ b/src/Components/Results/211Button/211Button.tsx
@@ -5,17 +5,15 @@ const HelpButton = () => {
   return (
     <div className="help-text-for-211-button">
       <h2 className="text-center help-text-for-211-button-font">{`Can't find what you need?`}</h2>
-      <div>
-        <a
-          href="https://www.211colorado.org/"
-          className="button211"
-          target="_blank"
-          rel="noreferrer"
-          aria-label="More Help at 2-1-1"
-        >
-          <FormattedMessage id="more_help_at_2-1-1" defaultMessage="More Help at 2-1-1" />
-        </a>
-      </div>
+      <a
+        href="https://www.211colorado.org/"
+        className="button211"
+        target="_blank"
+        rel="noreferrer"
+        aria-label="More Help at 2-1-1"
+      >
+        <FormattedMessage id="more_help_at_2-1-1" defaultMessage="More Help at 2-1-1" />
+      </a>
     </div>
   );
 };

--- a/src/Components/Results/211Button/211Button.tsx
+++ b/src/Components/Results/211Button/211Button.tsx
@@ -5,13 +5,7 @@ const HelpButton = () => {
   return (
     <div className="help-text-for-211-button">
       <h2 className="text-center help-text-for-211-button-font">{`Can't find what you need?`}</h2>
-      <a
-        href="https://www.211colorado.org/"
-        className="button211"
-        target="_blank"
-        rel="noreferrer"
-        aria-label="More Help at 2-1-1"
-      >
+      <a href="https://www.211colorado.org/" className="button211" target="_blank" aria-label="More Help at 2-1-1">
         <FormattedMessage id="more_help_at_2-1-1" defaultMessage="More Help at 2-1-1" />
       </a>
     </div>

--- a/src/Components/Results/CategoryHeading/CategoryHeading.tsx
+++ b/src/Components/Results/CategoryHeading/CategoryHeading.tsx
@@ -5,9 +5,10 @@ import { ReactComponent as Transportation } from '../../../Assets/CategoryHeadin
 import { ReactComponent as TaxCredits } from '../../../Assets/CategoryHeadingIcons/taxCredits.svg';
 import { ReactComponent as CashAssistance } from '../../../Assets/CategoryHeadingIcons/cashAssistant.svg';
 import { ReactComponent as ChildCareYouthEducation } from '../../../Assets/CategoryHeadingIcons/childCareYouthEducation.svg';
-import ResultsTranslate from '../Translate/Translate.tsx';
-import { calculateTotalValue, useResultsContext } from '../Results';
+import { calculateTotalValue, formatToUSD, useResultsContext } from '../Results';
 import { Translation } from '../../../Types/Results.ts';
+import { FormattedMessage } from 'react-intl';
+import ResultsTranslate from '../Translate/Translate.tsx';
 
 export const headingOptionsMappings: { [key: string]: React.ComponentType } = {
   'Housing and Utilities': Housing,
@@ -33,7 +34,7 @@ const CategoryHeading: React.FC<CategoryHeadingProps> = ({ headingType }) => {
     IconComponent = CashAssistance;
   }
 
-  const amount = calculateTotalValue(programs, headingType.default_message);
+  const monthlyCategoryAmt = calculateTotalValue(programs, headingType.default_message) / 12;
 
   return (
     <div className="category-heading-container">
@@ -46,7 +47,10 @@ const CategoryHeading: React.FC<CategoryHeadingProps> = ({ headingType }) => {
         </h2>
       </div>
       <div className="box-right">
-        <h2 className="category-heading-text-style normal-weight">${amount}/mo.</h2>
+        <h2 className="category-heading-text-style normal-weight">
+          {formatToUSD(monthlyCategoryAmt)}
+          <FormattedMessage id="program-card-month-txt" defaultMessage="/month" />
+        </h2>
       </div>
     </div>
   );

--- a/src/Components/Results/Needs/NeedCard.tsx
+++ b/src/Components/Results/Needs/NeedCard.tsx
@@ -47,7 +47,7 @@ const NeedCard = ({ need }: NeedsCardProps) => {
             <ResultsTranslate translation={need.name} />
           </strong>
         </span>
-        <a className="resource-more-info" href={translatedLink} target="_blank" rel="noreferrer">
+        <a className="resource-more-info" href={translatedLink} target="_blank">
           <FormattedMessage id="more-info" defaultMessage="More Info" />
         </a>
       </div>

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -13,7 +13,7 @@
 .program-icon-and-header {
   display: flex;
   align-items: center;
-  justify-content: start;
+  justify-content: end;
   width: 100%;
 }
 
@@ -30,7 +30,8 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  width: 60%;
+  width: 100%;
+  margin-right: 1rem;
 }
 
 .header-text-top {
@@ -38,6 +39,7 @@
   align-items: center;
   color: var(--secondary-color);
   height: 30%;
+  text-wrap: nowrap;
 }
 
 .header-text-bottom {
@@ -46,12 +48,13 @@
   display: flex;
   align-items: center;
   text-transform: capitalize;
+  text-wrap: nowrap;
 }
 
 .divider {
   margin: 0.25rem 0;
   border-bottom: 0.07rem solid var(--main-header-color);
-  width: 40%;
+  width: 100%;
 }
 
 .estimation {
@@ -77,8 +80,8 @@
 }
 
 .estimation-text-left {
-  float: left;
   text-align: left;
+  margin-right: 1rem;
 }
 
 .apply-online-button {
@@ -178,6 +181,11 @@ li.apply-info {
   margin-bottom: 2rem;
 }
 
+.icon-header-est-values {
+  display: flex;
+  justify-content: space-evenly;
+}
+
 /* TABLET */
 @media (max-width: 750px) {
   .divider {
@@ -190,5 +198,14 @@ li.apply-info {
 
   .program-icon-and-header {
     justify-content: center;
+  }
+
+  .icon-header-est-values {
+    display: block;
+    width: 100%;
+  }
+
+  .estimation-text-left {
+    text-wrap: wrap;
   }
 }

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -49,6 +49,7 @@
   align-items: center;
   text-transform: capitalize;
   text-wrap: nowrap;
+  font-size: 2rem;
 }
 
 .divider {
@@ -95,6 +96,7 @@
   font-weight: 700;
   padding: 0.25rem 3rem;
   margin-bottom: 2rem;
+  width: 19rem;
 }
 
 .apply-online-button a {
@@ -187,6 +189,10 @@ li.apply-info {
 
 .content-header {
   font-size: 1.25rem;
+}
+
+.slim-text {
+  font-weight: 400;
 }
 
 /* TABLET */

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -62,12 +62,13 @@
 
 .estimation {
   background-color: var(--main-header-color);
-  padding: 0.75rem;
+  padding: 1rem;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-weight: 700;
+  width: 100%;
 }
 
 .estimation-text {
@@ -84,7 +85,6 @@
 .estimation-text-left {
   float: left;
   text-align: left;
-  margin-right: 5rem;
 }
 
 .estimation-text-right {
@@ -207,11 +207,7 @@ li.apply-info {
     width: 100%;
   }
 
-  .apply-online-button {
-    padding: 3px 8rem;
-  }
-
   .program-description {
-    width: 50%;
+    width: 85%;
   }
 }

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -65,6 +65,7 @@
   align-items: center;
   justify-content: center;
   font-weight: 700;
+  font-size: 1.1rem;
   width: 100%;
 }
 
@@ -121,7 +122,7 @@
 .apply-box-list {
   text-align: left;
   list-style-type: none;
-  font-size: small;
+  font-size: 1rem;
   font-family: 'Roboto Slab', serif;
   font-weight: 700;
   padding-left: 1rem;
@@ -165,13 +166,14 @@ li.apply-info {
   padding-left: 1rem;
   line-height: 1.5rem;
   padding-top: 0.5rem;
-  font-size: small;
+  font-size: 1rem;
   font-weight: 700;
   font-family: 'Open Sans', sans-serif;
 }
 
 .program-description {
   margin-bottom: 2rem;
+  font-size: 1rem;
 }
 
 .icon-header-est-values {
@@ -181,6 +183,10 @@ li.apply-info {
 
 .content-width {
   width: 75%;
+}
+
+.content-header {
+  font-size: 1.25rem;
 }
 
 /* TABLET */

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -81,11 +81,6 @@
   text-align: left;
 }
 
-.estimation-text-right {
-  text-align: right;
-  font-weight: 400;
-}
-
 .apply-online-button {
   border-radius: 1.5rem;
   text-align: center;

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -88,14 +88,12 @@
   border-radius: 1.5rem;
   text-align: center;
   margin-top: 2rem;
-  width: 30%;
-  white-space: nowrap;
-  min-width: max-content;
+  width: 75%;
   background-color: var(--primary-color);
   color: white;
   font-size: large;
   font-weight: 700;
-  padding: 0.07rem 3rem;
+  padding: 0.25rem 3rem;
   margin-bottom: 2rem;
 }
 
@@ -118,7 +116,7 @@
   margin-bottom: 2rem;
   color: var(--primary-color);
   font-weight: 400;
-  width: 25%;
+  width: 75%;
   min-width: 20rem;
   text-align: center;
 }
@@ -158,11 +156,11 @@ li.apply-info {
   text-align: center;
   display: flex;
   flex-direction: column;
-  height: fit-content;
   padding: 1rem;
   margin-bottom: 2rem;
   color: var(--primary-color);
   font-weight: 400;
+  width: 75%;
 }
 
 .required-docs-list {
@@ -177,7 +175,7 @@ li.apply-info {
 }
 
 .program-description {
-  width: 30%;
+  width: 75%;
   margin-bottom: 2rem;
 }
 
@@ -208,5 +206,9 @@ li.apply-info {
   .estimation-text-left {
     text-wrap: wrap;
     margin: 0;
+  }
+
+  .apply-box, .required-docs {
+    width: 85%;
   }
 }

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -7,7 +7,7 @@
 }
 
 .back-to-results-button-container {
-  width: 45%;
+  width: 100%;
 }
 
 .program-header {
@@ -15,7 +15,6 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  margin: 1rem 0;
 }
 
 .header-icon-box {
@@ -190,21 +189,10 @@ li.apply-info {
   margin-bottom: 2rem;
 }
 
-/* DESKTOP */
-@media (max-width: 950px) {
-  .back-to-results-button-container {
-    width: 60%;
-  }
-}
-
 /* TABLET */
 @media (max-width: 750px) {
   .divider {
     width: 70%;
-  }
-
-  .back-to-results-button-container {
-    width: 100%;
   }
 
   .program-description {

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -10,22 +10,17 @@
   width: 100%;
 }
 
-.program-header {
+.program-icon-and-header {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: start;
   width: 100%;
 }
 
 .header-icon-box {
-  align-items: center;
   display: flex;
-  justify-content: flex-end;
-  margin-right: 0.5rem;
-  width: 40%;
-}
-
-.header-icon {
+  justify-content: start;
+  align-items: center;
   height: 6rem;
   width: 6rem;
   fill: var(--main-header-color);
@@ -88,7 +83,6 @@
 
 .estimation-text-right {
   text-align: right;
-  margin-left: 5rem;
   font-weight: 400;
 }
 
@@ -197,5 +191,9 @@ li.apply-info {
 
   .program-description {
     width: 85%;
+  }
+
+  .program-icon-and-header {
+    justify-content: center;
   }
 }

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -88,10 +88,9 @@
   border-radius: 1.5rem;
   text-align: center;
   margin-top: 2rem;
-  width: 75%;
   background-color: var(--primary-color);
   color: white;
-  font-size: large;
+  font-size: 1.25rem;
   font-weight: 700;
   padding: 0.25rem 3rem;
   margin-bottom: 2rem;
@@ -116,8 +115,6 @@
   margin-bottom: 2rem;
   color: var(--primary-color);
   font-weight: 400;
-  width: 75%;
-  min-width: 20rem;
   text-align: center;
 }
 
@@ -160,7 +157,6 @@ li.apply-info {
   margin-bottom: 2rem;
   color: var(--primary-color);
   font-weight: 400;
-  width: 75%;
 }
 
 .required-docs-list {
@@ -175,7 +171,6 @@ li.apply-info {
 }
 
 .program-description {
-  width: 75%;
   margin-bottom: 2rem;
 }
 
@@ -184,12 +179,12 @@ li.apply-info {
   justify-content: space-evenly;
 }
 
+.content-width {
+  width: 75%;
+}
+
 /* TABLET */
 @media (max-width: 750px) {
-  .program-description {
-    width: 85%;
-  }
-
   .program-icon-and-header {
     justify-content: center;
   }
@@ -206,9 +201,5 @@ li.apply-info {
   .estimation-text-left {
     text-wrap: wrap;
     margin: 0;
-  }
-
-  .apply-box, .required-docs {
-    width: 85%;
   }
 }

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -81,7 +81,7 @@
 
 .estimation-text-left {
   text-align: left;
-  margin-right: 1rem;
+  margin-right: 5rem;
 }
 
 .apply-online-button {
@@ -188,16 +188,16 @@ li.apply-info {
 
 /* TABLET */
 @media (max-width: 750px) {
-  .divider {
-    width: 70%;
-  }
-
   .program-description {
     width: 85%;
   }
 
   .program-icon-and-header {
     justify-content: center;
+  }
+
+  .header-text {
+    width: fit-content;
   }
 
   .icon-header-est-values {
@@ -207,5 +207,6 @@ li.apply-info {
 
   .estimation-text-left {
     text-wrap: wrap;
+    margin: 0;
   }
 }

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -48,18 +48,18 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
     return (
       <section className="estimation">
         <div className="estimation-text">
-          <div className="estimation-text-left">
+          <article className="estimation-text-left">
             <FormattedMessage id="results.estimated-annual-value" defaultMessage="Estimated Annual Value" />
-          </div>
-          <div className="estimation-text-right">{formatToUSD(program.estimated_value)}</div>
+          </article>
+          <article className="estimation-text-right slim-text">{formatToUSD(program.estimated_value)}</article>
         </div>
         <div className="estimation-text">
-          <div className="estimation-text-left">
+          <article className="estimation-text-left">
             <FormattedMessage id="results.estimated-time-to-apply" defaultMessage="Estimated Time to Apply" />
-          </div>
-          <div>
+          </article>
+          <article className="slim-text">
             <ResultsTranslate translation={program.estimated_application_time} />
-          </div>
+          </article>
         </div>
       </section>
     );
@@ -78,13 +78,12 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
         {displayIconAndHeader(program)}
         {displayEstimatedValueAndTime(program)}
       </div>
+      <div className="apply-online-button">
+        <Link to={program.apply_button_link.default_message} target="_blank" rel="noopener noreferrer">
+          <FormattedMessage id="results.apply-online" defaultMessage="Apply Online" />
+        </Link>
+      </div>
       <div className="content-width">
-        <div className="apply-online-button">
-          <Link to={program.apply_button_link.default_message} target="_blank" rel="noopener noreferrer">
-            <FormattedMessage id="results.apply-online" defaultMessage="Apply Online" />
-          </Link>
-        </div>
-
         {program.navigators.length > 0 && (
           <section className="apply-box">
             <h3 className="content-header">

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -56,7 +56,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
           <div className="estimation-text-left">
             <FormattedMessage id="results.estimated-time-to-apply" defaultMessage="Estimated Time to Apply" />
           </div>
-          <div className="estimation-text-right">
+          <div>
             <ResultsTranslate translation={program.estimated_application_time} />
           </div>
         </div>

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -4,6 +4,7 @@ import ResultsTranslate from '../Translate/Translate.tsx';
 import { headingOptionsMappings } from '../CategoryHeading/CategoryHeading.tsx';
 import BackAndSaveButtons from '../BackAndSaveButtons/BackAndSaveButtons.tsx';
 import { FormattedMessage } from 'react-intl';
+import { formatToUSD } from '../Results.tsx';
 import './ProgramPage.css';
 
 type ProgramPageProps = {
@@ -50,7 +51,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
           <div className="estimation-text-left">
             <FormattedMessage id="results.estimated-annual-value" defaultMessage="Estimated Annual Value" />
           </div>
-          <div className="estimation-text-right">${program.estimated_value}</div>
+          <div className="estimation-text-right">{formatToUSD(program.estimated_value)}</div>
         </div>
         <div className="estimation-text">
           <div className="estimation-text-left">

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -27,7 +27,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
     return <IconComponent />;
   };
 
-  const displayIconAndHeader = (program:Program) => {
+  const displayIconAndHeader = (program: Program) => {
     return (
       <header className="program-icon-and-header">
         <div className="header-icon-box">
@@ -63,7 +63,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
         </div>
       </section>
     );
-  }
+  };
 
   return (
     <article className="program-page-container">

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -79,9 +79,9 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
         {displayEstimatedValueAndTime(program)}
       </div>
       <div className="apply-online-button">
-        <Link to={program.apply_button_link.default_message} target="_blank" rel="noopener noreferrer">
+        <a href={program.apply_button_link.default_message} target="_blank">
           <FormattedMessage id="results.apply-online" defaultMessage="Apply Online" />
-        </Link>
+        </a>
       </div>
       <div className="content-width">
         {program.navigators.length > 0 && (
@@ -96,7 +96,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
                   <div className="address-info">
                     {info.assistance_link.default_message && (
                       <>
-                        <a href={info.assistance_link.default_message}>
+                        <a href={info.assistance_link.default_message} target="_blank">
                           <FormattedMessage id="results.visit-webiste" defaultMessage="Visit Website" />
                         </a>
                         <br />

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -15,6 +15,7 @@ type IconRendererProps = {
 };
 
 const ProgramPage = ({ program }: ProgramPageProps) => {
+  const { uuid } = useParams();
   const IconRenderer: React.FC<IconRendererProps> = ({ headingType }) => {
     const IconComponent = headingOptionsMappings[headingType];
 
@@ -25,25 +26,12 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
     return <IconComponent />;
   };
 
-  const { uuid } = useParams();
-
-  return (
-    <article className="program-page-container">
-      <section className="back-to-results-button-container">
-        <BackAndSaveButtons
-          handleTextfieldChange={() => {}}
-          navigateToLink={`/${uuid}/results/benefits`}
-          BackToThisPageText={<FormattedMessage id="results.back-to-results-btn" defaultMessage="BACK TO RESULTS" />}
-        />
-      </section>
-
-      <header className="program-header">
+  const displayIconAndHeader = (program:Program) => {
+    return (
+      <header className="program-icon-and-header">
         <div className="header-icon-box">
-          <div className="header-icon">
-            <IconRenderer headingType={program.category.default_message} />
-          </div>
+          <IconRenderer headingType={program.category.default_message} />
         </div>
-
         <div className="header-text">
           <p className="header-text-top">
             <ResultsTranslate translation={program.category} />
@@ -52,7 +40,11 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
           <h1 className="header-text-bottom">{program.name_abbreviated}</h1>
         </div>
       </header>
+    );
+  };
 
+  const displayEstimatedValueAndTime = (program: Program) => {
+    return (
       <section className="estimation">
         <div className="estimation-text">
           <div className="estimation-text-left">
@@ -69,6 +61,20 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
           </div>
         </div>
       </section>
+    );
+  }
+
+  return (
+    <article className="program-page-container">
+      <section className="back-to-results-button-container">
+        <BackAndSaveButtons
+          handleTextfieldChange={() => {}}
+          navigateToLink={`/${uuid}/results/benefits`}
+          BackToThisPageText={<FormattedMessage id="results.back-to-results-btn" defaultMessage="BACK TO RESULTS" />}
+        />
+      </section>
+      {displayIconAndHeader(program)}
+      {displayEstimatedValueAndTime(program)}
 
       <div className="apply-online-button">
         <Link to={program.apply_button_link.default_message} target="_blank" rel="noopener noreferrer">

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -78,67 +78,68 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
         {displayIconAndHeader(program)}
         {displayEstimatedValueAndTime(program)}
       </div>
+      <div className="content-width">
+        <div className="apply-online-button">
+          <Link to={program.apply_button_link.default_message} target="_blank" rel="noopener noreferrer">
+            <FormattedMessage id="results.apply-online" defaultMessage="Apply Online" />
+          </Link>
+        </div>
 
-      <div className="apply-online-button">
-        <Link to={program.apply_button_link.default_message} target="_blank" rel="noopener noreferrer">
-          <FormattedMessage id="results.apply-online" defaultMessage="Apply Online" />
-        </Link>
+        {program.navigators.length > 0 && (
+          <section className="apply-box">
+            <h3>
+              <FormattedMessage id="results.get-help-applying" defaultMessage="Get Help Applying" />
+            </h3>
+            <ul className="apply-box-list">
+              {program.navigators.map((info, index) => (
+                <li key={index} className="apply-info">
+                  {info.name && <ResultsTranslate translation={info.name} />}
+                  <div className="address-info">
+                    {info.assistance_link.default_message && (
+                      <>
+                        <a href={info.assistance_link.default_message}>
+                          <FormattedMessage id="results.visit-webiste" defaultMessage="Visit Website" />
+                        </a>
+                        <br />
+                      </>
+                    )}
+                    {info.email.default_message && (
+                      <>
+                        <a href={`mailto:${info.email}`}>
+                          <ResultsTranslate translation={info.email} />
+                        </a>
+                        <br />
+                      </>
+                    )}
+                    {info.phone_number && (
+                      <a href={`tel:${info.phone_number}`}>
+                        <FormattedMessage id="results.phone-number" defaultMessage={info.phone_number} />
+                      </a>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {program.documents.length > 0 && (
+          <section className="required-docs">
+            <h3>
+              <FormattedMessage id="results.required-documents-checklist" defaultMessage="Required Documents Checklist" />
+            </h3>
+            <ul className="required-docs-list">
+              {program.documents.map((document, index) => (
+                <li key={index}>
+                  <ResultsTranslate translation={document} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        <section className="program-description">
+          <ResultsTranslate translation={program.description} />
+        </section>
       </div>
-
-      {program.navigators.length > 0 && (
-        <section className="apply-box">
-          <h3>
-            <FormattedMessage id="results.get-help-applying" defaultMessage="Get Help Applying" />
-          </h3>
-          <ul className="apply-box-list">
-            {program.navigators.map((info, index) => (
-              <li key={index} className="apply-info">
-                {info.name && <ResultsTranslate translation={info.name} />}
-                <div className="address-info">
-                  {info.assistance_link.default_message && (
-                    <>
-                      <a href={info.assistance_link.default_message}>
-                        <FormattedMessage id="results.visit-webiste" defaultMessage="Visit Website" />
-                      </a>
-                      <br />
-                    </>
-                  )}
-                  {info.email.default_message && (
-                    <>
-                      <a href={`mailto:${info.email}`}>
-                        <ResultsTranslate translation={info.email} />
-                      </a>
-                      <br />
-                    </>
-                  )}
-                  {info.phone_number && (
-                    <a href={`tel:${info.phone_number}`}>
-                      <FormattedMessage id="results.phone-number" defaultMessage={info.phone_number} />
-                    </a>
-                  )}
-                </div>
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
-      {program.documents.length > 0 && (
-        <section className="required-docs">
-          <h3>
-            <FormattedMessage id="results.required-documents-checklist" defaultMessage="Required Documents Checklist" />
-          </h3>
-          <ul className="required-docs-list">
-            {program.documents.map((document, index) => (
-              <li key={index}>
-                <ResultsTranslate translation={document} />
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
-      <section className="program-description">
-        <ResultsTranslate translation={program.description} />
-      </section>
     </article>
   );
 };

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -73,8 +73,10 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
           BackToThisPageText={<FormattedMessage id="results.back-to-results-btn" defaultMessage="BACK TO RESULTS" />}
         />
       </section>
-      {displayIconAndHeader(program)}
-      {displayEstimatedValueAndTime(program)}
+      <div className="icon-header-est-values">
+        {displayIconAndHeader(program)}
+        {displayEstimatedValueAndTime(program)}
+      </div>
 
       <div className="apply-online-button">
         <Link to={program.apply_button_link.default_message} target="_blank" rel="noopener noreferrer">

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -87,7 +87,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
 
         {program.navigators.length > 0 && (
           <section className="apply-box">
-            <h3>
+            <h3 className="content-header">
               <FormattedMessage id="results.get-help-applying" defaultMessage="Get Help Applying" />
             </h3>
             <ul className="apply-box-list">
@@ -124,8 +124,11 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
         )}
         {program.documents.length > 0 && (
           <section className="required-docs">
-            <h3>
-              <FormattedMessage id="results.required-documents-checklist" defaultMessage="Required Documents Checklist" />
+            <h3 className="content-header">
+              <FormattedMessage
+                id="results.required-documents-checklist"
+                defaultMessage="Required Documents Checklist"
+              />
             </h3>
             <ul className="required-docs-list">
               {program.documents.map((document, index) => (

--- a/src/Components/Results/Programs/ProgramCard.css
+++ b/src/Components/Results/Programs/ProgramCard.css
@@ -80,10 +80,24 @@
     align-items: center;
   }
 
+  .category-heading-column {
+    flex: 1;
+  }
+
+  h2.category-heading-text-style.normal-weight {
+    display: block;
+    text-align: right;
+    width: 100%;
+  }
+
   .results-data-cell {
     display: flex;
     flex-direction: column-reverse;
     margin: 0.5rem 1rem;
+  }
+
+  .result-program-container:last-child {
+    margin-bottom: 3rem;
   }
 
   .column-row {

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -1,6 +1,7 @@
 import { Link, useParams } from 'react-router-dom';
 import { Program } from '../../../Types/Results';
 import { FormattedMessage } from 'react-intl';
+import { formatToUSD } from '../Results';
 import ResultsTranslate from '../Translate/Translate';
 
 type ProgramCardProps = {
@@ -14,10 +15,6 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
   const estimatedMonthlySavings = program.estimated_value / 12;
   const programName = program.name;
   const programId = program.program_id;
-
-  const formatToUSD = (num: number) => {
-    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(num);
-  };
 
   return (
     <div className="result-program-container">
@@ -36,7 +33,10 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
       </div>
       <div className="result-program-details">
         <FormattedMessage id="results.estimated_application_time" defaultMessage="Estimated Savings: " />
-        <strong>{formatToUSD(estimatedMonthlySavings)}<FormattedMessage id="program-card-month-txt" defaultMessage="/month" /></strong>
+        <strong>
+          {formatToUSD(estimatedMonthlySavings)}
+          <FormattedMessage id="program-card-month-txt" defaultMessage="/month" />
+        </strong>
       </div>
     </div>
   );

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -32,7 +32,7 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
         </strong>
       </div>
       <div className="result-program-details">
-        <FormattedMessage id="results.estimated_application_time" defaultMessage="Estimated Savings: " />
+        <FormattedMessage id="program-card.estimated-savings" defaultMessage="Estimated Savings: " />
         <strong>
           {formatToUSD(estimatedMonthlySavings)}
           <FormattedMessage id="program-card-month-txt" defaultMessage="/month" />

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -11,9 +11,13 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
   const { uuid } = useParams();
 
   const estimatedAppTime = program.estimated_application_time;
-  const estimatedSavings = program.estimated_value;
+  const estimatedMonthlySavings = program.estimated_value / 12;
   const programName = program.name;
   const programId = program.program_id;
+
+  const formatToUSD = (num: number) => {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(num);
+  };
 
   return (
     <div className="result-program-container">
@@ -32,7 +36,7 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
       </div>
       <div className="result-program-details">
         <FormattedMessage id="results.estimated_application_time" defaultMessage="Estimated Savings: " />
-        <strong>{`$${estimatedSavings}/mo`}</strong>
+        <strong>{formatToUSD(estimatedMonthlySavings)}<FormattedMessage id="program-card-month-txt" defaultMessage="/month" /></strong>
       </div>
     </div>
   );

--- a/src/Components/Results/Results.css
+++ b/src/Components/Results/Results.css
@@ -23,6 +23,7 @@
   text-decoration: none;
   background-color: #e6e7e8;
   color: var(--primary-color);
+  border-radius: 3rem 3rem 0 0;
 }
 .text-center {
   text-align: center !important;

--- a/src/Components/Results/Results.css
+++ b/src/Components/Results/Results.css
@@ -23,7 +23,7 @@
   text-decoration: none;
   background-color: #e6e7e8;
   color: var(--primary-color);
-  border-radius: 3rem 3rem 0 0;
+  border-radius: 2rem 2rem 0 0;
 }
 .text-center {
   text-align: center !important;

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -54,6 +54,10 @@ export function calculateTotalValue(programs: Program[], category: string) {
   return totalValue;
 }
 
+export const formatToUSD = (num: number) => {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(num);
+};
+
 const Results = ({ type, handleTextfieldChange }: ResultsProps) => {
   const { locale } = useContext(Context);
   const { uuid, programId } = useParams();

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -12,8 +12,6 @@ import Needs from './Needs/Needs';
 import Programs from './Programs/Programs';
 import ProgramPage from './ProgramPage/ProgramPage';
 import ResultsTabs from './Tabs/Tabs';
-import MoreHelp from './MoreHelp/MoreHelp';
-import NavigatorPage from './NavigatorPage/NavigatorPage';
 import { CitizenLabels } from '../../Assets/citizenshipFilterFormControlLabels';
 import dataLayerPush from '../../Assets/analytics';
 import HelpButton from './211Button/211Button';

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -59,8 +59,9 @@ export const formatToUSD = (num: number) => {
 };
 
 const Results = ({ type, handleTextfieldChange }: ResultsProps) => {
-  const { locale } = useContext(Context);
+  const { locale, formData } = useContext(Context);
   const { uuid, programId } = useParams();
+  const is211Co = formData.immutableReferrer === '211co';
 
   const [loading, setLoading] = useState(true);
   const [apiError, setApiError] = useState(false);
@@ -149,7 +150,7 @@ const Results = ({ type, handleTextfieldChange }: ResultsProps) => {
             {type === 'need' ? <Needs /> : <Programs />}
           </Grid>
         </Grid>
-        <HelpButton />
+        {!is211Co && <HelpButton />}
       </ResultsContext.Provider>
     );
   }

--- a/src/Components/Results/ResultsError/ResultsError.tsx
+++ b/src/Components/Results/ResultsError/ResultsError.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@mui/material';
-import ErrorIcon from '../../../Assets/error-icon.svg';
+import ErrorIcon from '../../../Assets/icons/error-icon.svg';
 import { useParams, useNavigate } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import './ResultsError.css';

--- a/src/Components/SignUp/SignUp.js
+++ b/src/Components/SignUp/SignUp.js
@@ -145,11 +145,7 @@ const SignUp = ({ handleTextfieldChange, handleCheckboxChange, submitted }) => {
                 defaultMessage="{linkVal}"
                 values={{
                   linkVal: (
-                    <a
-                      className="sign-up-data-privacy-link"
-                      href={privacyLink}
-                      target="_blank"
-                    >
+                    <a className="sign-up-data-privacy-link" href={privacyLink} target="_blank">
                       <FormattedMessage
                         id="signUp.displayDisclosureSection-consentCheckLink"
                         defaultMessage="data privacy policy "

--- a/src/Components/SignUp/SignUp.js
+++ b/src/Components/SignUp/SignUp.js
@@ -149,7 +149,6 @@ const SignUp = ({ handleTextfieldChange, handleCheckboxChange, submitted }) => {
                       className="sign-up-data-privacy-link"
                       href={privacyLink}
                       target="_blank"
-                      rel="noopener noreferrer"
                     >
                       <FormattedMessage
                         id="signUp.displayDisclosureSection-consentCheckLink"

--- a/src/Components/TwoOneOneComponents/TwoOneOneFooter/TwoOneOneFooter.tsx
+++ b/src/Components/TwoOneOneComponents/TwoOneOneFooter/TwoOneOneFooter.tsx
@@ -19,7 +19,6 @@ const TwoOneOneFooter = () => {
             href="https://www.211colorado.org/chat/#english"
             underline="none"
             target="_blank"
-            rel="noreferrer"
             aria-label="2-1-1 chat link"
             color="primary"
           >
@@ -42,7 +41,6 @@ const TwoOneOneFooter = () => {
             href="tel:211"
             underline="none"
             target="_blank"
-            rel="noreferrer"
             aria-label="2-1-1 dial link"
             color="primary"
             sx={{ display: 'inline-block' }}
@@ -59,7 +57,6 @@ const TwoOneOneFooter = () => {
             href="tel:866-760-6489"
             underline="none"
             target="_blank"
-            rel="noreferrer"
             aria-label="2-1-1 dial link"
             color="primary"
             sx={{ display: 'inline-block' }}
@@ -96,7 +93,6 @@ const TwoOneOneFooter = () => {
             href="sms:898211"
             underline="none"
             target="_blank"
-            rel="noreferrer"
             aria-label="2-1-1 chat link"
             color="primary"
             className="font-weight"
@@ -152,7 +148,6 @@ const TwoOneOneFooter = () => {
             href="https://www.211colorado.org/terms-of-service/"
             underline="none"
             target="_blank"
-            rel="noreferrer"
             aria-label="2-1-1 terms of service"
             className="privacy-policy-links"
           >
@@ -163,7 +158,6 @@ const TwoOneOneFooter = () => {
             href="https://www.211colorado.org/privacy-policy/"
             underline="none"
             target="_blank"
-            rel="noreferrer"
             aria-label="2-1-1 terms of service"
             className="privacy-policy-links"
           >
@@ -174,7 +168,6 @@ const TwoOneOneFooter = () => {
             href="https://www.myfriendben.org/en/data-privacy-policy"
             underline="none"
             target="_blank"
-            rel="noreferrer"
             aria-label="2-1-1 terms of service"
             className="privacy-policy-links"
           >

--- a/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
+++ b/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
@@ -75,7 +75,6 @@ const TwoOneOneHeader = ({ handleTextfieldChange }) => {
           href={link.href}
           underline="none"
           target="_blank"
-          rel="noreferrer"
           aria-label={link.ariaLabel}
           className="twoOneOneMenuLink"
           key={link.defaultMsg + index}


### PR DESCRIPTION
What (if anything) did you refactor?
-  Reduce padding between tab and Filter
-  Calculations on headings and benefits cards need to be per month. They're displaying annual value right now. 
- Program page: move estimated values box to the right of the name of benefits box
- Program page: Make get help applying box documents box wider on desktop + paragraph wider
- Program page desktop: smallest font should be 16, go up from there for rest of headings.
- Padding under 2-1-1 button (between button & footer)
- Remove the 211 text and button from the 211 site.

Were there any issues that arose?
- Some of the links were not working, we'll definitely need to test these to make sure they're fixed now.
