### PR TITLE
Results Page Updates: Category Headings

### DIFF
--- a/src/Components/Results/CategoryHeading/CategoryHeading.tsx
+++ b/src/Components/Results/CategoryHeading/CategoryHeading.tsx
@@ -37,7 +37,7 @@ const CategoryHeading: React.FC<CategoryHeadingProps> = ({ headingType }) => {
 
   return (
     <div className="category-heading-container">
-      <div className="box-left">
+      <div className="category-heading-column">
         <div className="category-heading-icon" aria-label={`${headingType.default_message} icon`}>
           <IconComponent />
         </div>
@@ -45,7 +45,7 @@ const CategoryHeading: React.FC<CategoryHeadingProps> = ({ headingType }) => {
           <ResultsTranslate translation={headingType} />
         </h2>
       </div>
-      <div className="box-right">
+      <div className="category-heading-column">
         <h2 className="category-heading-text-style normal-weight">${amount}/mo.</h2>
       </div>
     </div>

--- a/src/Components/Results/Results.css
+++ b/src/Components/Results/Results.css
@@ -52,22 +52,31 @@
 
 .category-heading-container {
   display: flex;
-  justify-content: space-between;
-}
-
-.category-heading-icon {
-  height: 2rem;
-  width: 2rem;
-  fill: var(--icon-color);
-}
-
-.category-heading-container .box-left,
-.category-heading-container .box-right {
-  display: flex;
+  flex-wrap: wrap;
   align-items: center;
 }
 
+.category-heading-column {
+  flex: 0 0 100%;
+  min-width: 0;
+  text-align: left;
+}
+
+.category-heading-icon {
+  display: inline-flex;
+}
+
+.category-heading-column,
+.category-heading-column svg {
+  display: inline-flex;
+  width: 2.5rem;
+  fill: var(--icon-color);
+}
+
 .category-heading-text-style {
+  display: inline-flex;
+  margin-left: 0.25rem;
+  align-self: center;
   font-family: 'Roboto Slab', serif;
   font-weight: 700;
   color: var(--secondary-color);
@@ -116,6 +125,10 @@
   position: relative;
   border: 2px solid var(--secondary-color);
   margin-bottom: 1rem;
+}
+
+.result-program-container:last-child {
+  margin-bottom: 2rem;
 }
 
 .result-program-container hr {
@@ -231,6 +244,16 @@
     align-items: center;
   }
 
+  .category-heading-column {
+    flex: 1;
+  }
+
+  h2.category-heading-text-style.normal-weight {
+    display: block;
+    text-align: right;
+    width: 100%;
+  }
+
   .results-data-cell {
     display: flex;
     flex-direction: column-reverse;
@@ -281,6 +304,10 @@
     position: relative;
     display: flex;
     align-items: center;
+  }
+
+  .result-program-container:last-child {
+    margin-bottom: 3rem;
   }
 
   .result-program-more-info {


### PR DESCRIPTION
What (if anything) did you refactor?
- Updated result program card styling. Icon sizes increased. Card headers now stack on mobile. Increased margin between each card.

<img width="956" alt="Screenshot 2024-02-16 at 11 17 05 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/7133950/0609b782-e7a4-4d49-b07e-e79688f26faf">
<img width="354" alt="Screenshot 2024-02-16 at 11 16 46 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/7133950/19c72826-c8ea-4326-9cd2-e597746c59c5">
