### PR TITLE
Transform configResponse data

### DIFF
--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -4,26 +4,31 @@ import { ConfigApiResponse } from '../../Types/Config';
 import { Config } from '../../Types/Config';
 import { FormattedMessage } from 'react-intl';
 
-// Recursive function
-function transformItem(item: any): any {
+// Recursively transform any object that has _label, and _default_message as keys into a FormattedMessage
+function transformItem(item: unknown): any {
+  type Item = {
+    _label: string;
+    _default_message: string;
+  };
+
   if (typeof item !== 'object' || item === null) {
     return item;
   }
 
-  if (item.hasOwnProperty('_label')) {
-    return <FormattedMessage id={item._label} defaultMessage={item._default_message} />;
+  if (item.hasOwnProperty('_label') && item.hasOwnProperty('_default_message')) {
+    const { _label, _default_message } = item as Item;
+    return <FormattedMessage id={_label} defaultMessage={_default_message} />;
   }
 
   const config: Config = {};
   for (const key in item) {
     if (item.hasOwnProperty(key)) {
-      config[key] = transformItem(item[key]);
+      config[key] = transformItem((item as any)[key]);
     }
   }
   return config;
 }
 
-// Main function with recursion
 function transformConfigResponse(configResponse: ConfigApiResponse[]): Config {
   const output: Config = {};
 

--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -1,14 +1,34 @@
 import { useEffect, useState } from 'react';
 import { configEndpoint, header } from '../../apiCalls';
-
 import { ConfigApiResponse } from '../../Types/Config';
 import { Config } from '../../Types/Config';
+import { FormattedMessage } from 'react-intl';
 
+// Recursive function
+function transformItem(item: any): any {
+  if (typeof item !== 'object' || item === null) {
+    return item;
+  }
+
+  if (item.hasOwnProperty('_label')) {
+    return <FormattedMessage id={item._label} defaultMessage={item._default_message} />;
+  }
+
+  const config: Config = {};
+  for (const key in item) {
+    if (item.hasOwnProperty(key)) {
+      config[key] = transformItem(item[key]);
+    }
+  }
+  return config;
+}
+
+// Main function with recursion
 function transformConfigResponse(configResponse: ConfigApiResponse[]): Config {
   const output: Config = {};
 
   configResponse.forEach((item) => {
-    output[item.name] = item.data;
+    output[item.name] = transformItem(item.data);
   });
 
   return output;


### PR DESCRIPTION
What (if any) features are you implementing?
- Updated `transformConfigResponse` function to handle potentially nested `configResponse` data.

Any other comments, questions, or concerns?
- Please let me know if it makes sense.