### PR TITLE
885/Adding Low Confidence flag

### DIFF
--- a/src/Components/Results/Programs/ProgramCard.css
+++ b/src/Components/Results/Programs/ProgramCard.css
@@ -77,8 +77,8 @@
   font-size: 0.8125rem;
   position: absolute;
   top: 0;
-  left: 88px;
-  z-index: 99
+  left: 5.5rem;
+  z-index: 99;
 }
 
 h1.header-text-bottom {

--- a/src/Components/Results/Programs/ProgramCard.css
+++ b/src/Components/Results/Programs/ProgramCard.css
@@ -63,6 +63,22 @@
   position: absolute;
   top: 0;
   left: 0;
+  z-index: 100;
+}
+
+.low-confidence-flag {
+  font-weight: bold;
+  font-family: 'Roboto Slab', serif;
+  background-color: var(--hover-color);
+  padding-left: 1rem;
+  color: var(--primary-color);
+  width: 8rem;
+  border-radius: 0 0 0.75rem 0;
+  font-size: 0.8125rem;
+  position: absolute;
+  top: 0;
+  left: 88px;
+  z-index: 99
 }
 
 h1.header-text-bottom {

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -50,7 +50,7 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
         </div>
       )}
       {program.low_confidence && (
-        <div className="low-confidence-flag" style={{left:`${program.new ? "88px" : "0"} `}}>
+        <div className="low-confidence-flag" style={{ left: `${program.new ? '5.5rem' : '0'} ` }}>
           <FormattedMessage id="results-low-confidence-flag" defaultMessage="Low Confidence" />
         </div>
       )}

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -49,6 +49,11 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
           <FormattedMessage id="results-new-benefit-flag" defaultMessage="New Benefit" />
         </div>
       )}
+      {program.low_confidence && (
+        <div className="low-confidence-flag" style={{left:`${program.new ? "88px" : "0"} `}}>
+          <FormattedMessage id="results-low-confidence-flag" defaultMessage="Low Confidence" />
+        </div>
+      )}
       <ConditonalWrapper
         condition={isMobile}
         wrapper={(children) => <div className="result-program-more-info-wrapper">{children}</div>}


### PR DESCRIPTION
## What (if any) features are you implementing?

Work for the issue [885](https://github.com/Gary-Community-Ventures/benefits-calculator/issues/885)
Adding 'Low Confidence Flag' to the result page

Look with existing 'New Benefit' flag

![image](https://github.com/Gary-Community-Ventures/benefits-calculator/assets/65931890/7214bb75-6294-408e-8d1e-e0a30c223e70)

Look without first 'New Benefit' flag

![image](https://github.com/Gary-Community-Ventures/benefits-calculator/assets/65931890/125f80fb-9f18-43a2-83fc-ea39be38d854)
