### PR TITLE
971/help bubble text

### DIFF
--- a/src/Assets/questions.tsx
+++ b/src/Assets/questions.tsx
@@ -21,6 +21,7 @@ import signUpOptions from './signUpOptions.tsx';
 import acuteConditionOptions from './acuteConditionOptions';
 import { FormattedMessage } from 'react-intl';
 import type { QuestionName, Question } from '../Types/Questions.ts';
+import HelpButton from '../Components/HelpBubbleIcon/HelpButton.tsx';
 
 const questions: Record<QuestionName, Question> = {
   zipcode: {
@@ -67,16 +68,17 @@ const questions: Record<QuestionName, Question> = {
     name: 'householdSize',
     header: <FormattedMessage id="qcc.about_household" defaultMessage="Tell us about your household" />,
     question: (
-      <FormattedMessage
-        id="questions.householdSize"
-        defaultMessage="Including you, how many people are in your household?"
-      />
-    ),
-    questionDescription: (
-      <FormattedMessage
-        id="questions.householdSize-description"
-        defaultMessage="This is usually family members whom you live with and share important resources with like food and bills."
-      />
+      <>
+        <FormattedMessage
+          id="questions.householdSize"
+          defaultMessage="Including you, how many people are in your household?"
+        />
+        <HelpButton
+          isVisible={true}
+          helpText="This is usually family members who you both live and share important resources with like food and bills."
+          helpId="questions.householdSize-helpText"
+        ></HelpButton>
+      </>
     ),
     componentDetails: {
       componentType: 'Textfield',
@@ -99,14 +101,16 @@ const questions: Record<QuestionName, Question> = {
   hasExpenses: {
     name: 'hasExpenses',
     header: <FormattedMessage id="qcc.about_household" defaultMessage="Tell us about your household" />,
-    question: <FormattedMessage id="questions.hasExpenses" defaultMessage="Does your household have any expenses?" />,
-    questionDescription: (
-      <FormattedMessage
-        id="questions.hasExpenses-description"
-        defaultMessage="Add up expenses for everyone who lives in your home.
-          This includes costs like child care, child support, rent, medical expenses, heating bills, and more.
-          We will ask only about expenses that may affect benefits. We will not ask about expenses such as food since grocery bills do not affect benefits."
-      />
+    question: (
+      <>
+        {' '}
+        <FormattedMessage id="questions.hasExpenses" defaultMessage="Does your household have any expenses?" />{' '}
+        <HelpButton
+          isVisible={true}
+          helpText="Add up expenses for everyone who lives in your home. This includes costs like child care, child support, rent, medical expenses, heating bills, and more. We will ask only about expenses that may affect benefits. We will not ask about expenses such as food since grocery bills do not affect benefits."
+          helpId="questions.hasExpenses-description"
+        />
+      </>
     ),
     componentDetails: {
       componentType: 'Radiofield',
@@ -135,16 +139,17 @@ const questions: Record<QuestionName, Question> = {
     name: 'householdAssets',
     header: <FormattedMessage id="qcc.about_household" defaultMessage="Tell us about your household" />,
     question: (
-      <FormattedMessage
-        id="questions.householdAssets"
-        defaultMessage="How much does your whole household have right now in:"
-      />
-    ),
-    questionDescription: (
-      <FormattedMessage
-        id="questions.householdAssets-description"
-        defaultMessage="Cash on hand? Checking or saving accounts? Stocks, bonds or mutual funds? In some cases, eligibility for benefits may be affected if your household owns other valuable assets such as a car or life insurance policy."
-      />
+      <>
+        <FormattedMessage
+          id="questions.householdAssets"
+          defaultMessage="How much does your whole household have right now in:"
+        />
+        <HelpButton
+          isVisible={true}
+          helpText="In some cases, eligibility for benefits may be affected if your household owns other valuable assets such as a car or life insurance policy."
+          helpId="questions.householdAssets-description"
+        />
+      </>
     ),
     componentDetails: {
       componentType: 'Textfield',
@@ -166,13 +171,17 @@ const questions: Record<QuestionName, Question> = {
       />
     ),
     question: (
-      <FormattedMessage id="questions.hasBenefits" defaultMessage="Does your household currently have any benefits?" />
-    ),
-    questionDescription: (
-      <FormattedMessage
-        id="questions.hasBenefits-description"
-        defaultMessage="This information will help make sure we don't give you results for benefits you already have."
-      />
+      <>
+        <FormattedMessage
+          id="questions.hasBenefits"
+          defaultMessage="Does your household currently have any benefits?"
+        />
+        <HelpButton
+          isVisible={true}
+          helpText="This information will help make sure we don't give you results for benefits you already have."
+          helpId="questions.hasBenefits-description"
+        />
+      </>
     ),
     componentDetails: {
       componentType: 'PreferNotToAnswer',

--- a/src/Assets/questions.tsx
+++ b/src/Assets/questions.tsx
@@ -74,7 +74,6 @@ const questions: Record<QuestionName, Question> = {
           defaultMessage="Including you, how many people are in your household?"
         />
         <HelpButton
-          isVisible={true}
           helpText="This is usually family members who you both live and share important resources with like food and bills."
           helpId="questions.householdSize-helpText"
         ></HelpButton>
@@ -105,7 +104,6 @@ const questions: Record<QuestionName, Question> = {
       <>
         <FormattedMessage id="questions.hasExpenses" defaultMessage="Does your household have any expenses?" />{' '}
         <HelpButton
-          isVisible={true}
           helpText="Add up expenses for everyone who lives in your home. This includes costs like child care, child support, rent, medical expenses, heating bills, and more. We will ask only about expenses that may affect benefits. We will not ask about expenses such as food since grocery bills do not affect benefits."
           helpId="questions.hasExpenses-description"
         />
@@ -141,10 +139,9 @@ const questions: Record<QuestionName, Question> = {
       <>
         <FormattedMessage
           id="questions.householdAssets"
-          defaultMessage="How much does your whole household have right now in:"
+          defaultMessage="How much does your whole household have right now in cash, checking or savings accounts, stocks, bonds, or mutual funds?"
         />
         <HelpButton
-          isVisible={true}
           helpText="In some cases, eligibility for benefits may be affected if your household owns other valuable assets such as a car or life insurance policy."
           helpId="questions.householdAssets-description"
         />
@@ -176,7 +173,6 @@ const questions: Record<QuestionName, Question> = {
           defaultMessage="Does your household currently have any benefits?"
         />
         <HelpButton
-          isVisible={true}
           helpText="This information will help make sure we don't give you results for benefits you already have."
           helpId="questions.hasBenefits-description"
         />

--- a/src/Assets/questions.tsx
+++ b/src/Assets/questions.tsx
@@ -103,7 +103,6 @@ const questions: Record<QuestionName, Question> = {
     header: <FormattedMessage id="qcc.about_household" defaultMessage="Tell us about your household" />,
     question: (
       <>
-        {' '}
         <FormattedMessage id="questions.hasExpenses" defaultMessage="Does your household have any expenses?" />{' '}
         <HelpButton
           isVisible={true}

--- a/src/Components/HelpBubbleIcon/HelpButton.tsx
+++ b/src/Components/HelpBubbleIcon/HelpButton.tsx
@@ -3,15 +3,7 @@ import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { ReactComponent as HelpBubble } from '../../Assets/icons/helpBubble.svg';
 
-const HelpButton = ({
-  className,
-  helpText,
-  helpId,
-}: {
-  className?: string;
-  helpText: string;
-  helpId: string;
-}) => {
+const HelpButton = ({ className, helpText, helpId }: { className?: string; helpText: string; helpId: string }) => {
   const [showHelpText, setShowHelpText] = useState(false);
 
   const handleClick = () => {
@@ -19,15 +11,15 @@ const HelpButton = ({
   };
 
   return (
-      <>
-        <IconButton onClick={handleClick}>
-          <HelpBubble style={{ height: '20px', width: '20px' }} />
-        </IconButton>
-        <p className={`${className} question-description help-text`}>
-          {showHelpText && <FormattedMessage id={helpId} defaultMessage={helpText} />}
-        </p>
-      </>
-    )
+    <>
+      <IconButton onClick={handleClick}>
+        <HelpBubble style={{ height: '20px', width: '20px' }} />
+      </IconButton>
+      <p className={`${className} question-description help-text`}>
+        {showHelpText && <FormattedMessage id={helpId} defaultMessage={helpText} />}
+      </p>
+    </>
+  );
 };
 
 export default HelpButton;

--- a/src/Components/HelpBubbleIcon/HelpButton.tsx
+++ b/src/Components/HelpBubbleIcon/HelpButton.tsx
@@ -7,12 +7,10 @@ const HelpButton = ({
   className,
   helpText,
   helpId,
-  isVisible,
 }: {
   className?: string;
   helpText: string;
   helpId: string;
-  isVisible: boolean;
 }) => {
   const [showHelpText, setShowHelpText] = useState(false);
 
@@ -21,7 +19,6 @@ const HelpButton = ({
   };
 
   return (
-    isVisible && (
       <>
         <IconButton onClick={handleClick}>
           <HelpBubble style={{ height: '20px', width: '20px' }} />
@@ -31,7 +28,6 @@ const HelpButton = ({
         </p>
       </>
     )
-  );
 };
 
 export default HelpButton;

--- a/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
+++ b/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
@@ -375,7 +375,6 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
           <h2 className="question-label">
             <FormattedMessage id={formattedMsgId} defaultMessage={formattedMsgDefaultMsg} />
             <HelpButton
-              isVisible={true}
               helpText="This includes money from jobs, alimony, investments, or gifts. Income is the money earned or received before deducting taxes"
               helpId="householdDataBlock.createIncomeRadioQuestion-questionDescription"
             ></HelpButton>

--- a/src/Components/IncomeBlock/PersonIncomeBlock.css
+++ b/src/Components/IncomeBlock/PersonIncomeBlock.css
@@ -33,7 +33,7 @@
 }
 
 .income-question-padding {
-  padding: 1.5em 0;
+  padding: 0.5rem 0;
 }
 
 .income-stream-q-padding {

--- a/src/Components/IncomeBlock/PersonIncomeBlock.js
+++ b/src/Components/IncomeBlock/PersonIncomeBlock.js
@@ -3,6 +3,7 @@ import { Button, Box } from '@mui/material';
 import { useEffect, useState } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import IncomeQuestion from './IncomeQuestion';
+import HelpButton from '../../Components/HelpBubbleIcon/HelpButton.tsx';
 import './PersonIncomeBlock.css';
 
 const PersonIncomeBlock = ({ memberData, setMemberData, page, submitted }) => {
@@ -78,13 +79,12 @@ const PersonIncomeBlock = ({ memberData, setMemberData, page, submitted }) => {
               id={renderFollowUpIncomeQIdAndDefaultMsg(page)[0]}
               defaultMessage={renderFollowUpIncomeQIdAndDefaultMsg(page)[1]}
             />
-          </h2>
-          <p className="question-description">
-            <FormattedMessage
-              id="personIncomeBlock.return-questionDescription"
-              defaultMessage="Answer the best you can. You will be able to include additional types of income. The more you include, the more accurate your results will be."
+            <HelpButton
+              isVisible={true}
+              helpText="Answer the best you can. You will be able to include additional types of income. The more you include, the more accurate your results will be."
+              helpId="personIncomeBlock.return-questionDescription"
             />
-          </p>
+          </h2>
         </Box>
       </div>
       {createIncomeBlockQuestions()}

--- a/src/Components/IncomeBlock/PersonIncomeBlock.js
+++ b/src/Components/IncomeBlock/PersonIncomeBlock.js
@@ -80,7 +80,6 @@ const PersonIncomeBlock = ({ memberData, setMemberData, page, submitted }) => {
               defaultMessage={renderFollowUpIncomeQIdAndDefaultMsg(page)[1]}
             />
             <HelpButton
-              isVisible={true}
               helpText="Answer the best you can. You will be able to include additional types of income. The more you include, the more accurate your results will be."
               helpId="personIncomeBlock.return-questionDescription"
             />


### PR DESCRIPTION
## What (if any) features are you implementing?

Work for the issue #971 
Adding help text behind help bubble

https://github.com/Gary-Community-Ventures/benefits-calculator/assets/65931890/e4b98f1c-453b-4566-b931-308817175adb

For question 7, the translation file needs to be updated to display correct help text `'In some cases, eligibility for benefits may be affected if your household owns other valuable assets such as a car or life insurance policy.'` and question stem to say `"How much does your whole household have right now in cash, checking or savings accounts, stocks, bonds, or mutual funds?"`