### PR TITLE
Results Tax Credit displayed with comma(s) if appropriate

### DIFF
--- a/src/Components/Results/ResultsHeader/ResultsHeader.tsx
+++ b/src/Components/Results/ResultsHeader/ResultsHeader.tsx
@@ -48,7 +48,7 @@ const ProgramsHeader = () => {
           </section>
           {formData.immutableReferrer !== 'lgs' && (
             <section className="results-data-cell">
-              <div className="results-header-values">${taxCredit}</div>
+              <div className="results-header-values">${taxCredit.toLocaleString()}</div>
               <div className="results-header-label">
                 <FormattedMessage id="results.header-taxCredits" defaultMessage="Annual Tax Credit" />
               </div>

--- a/src/Components/Results/ResultsHeader/ResultsHeader.tsx
+++ b/src/Components/Results/ResultsHeader/ResultsHeader.tsx
@@ -48,7 +48,7 @@ const ProgramsHeader = () => {
           </section>
           {formData.immutableReferrer !== 'lgs' && (
             <section className="results-data-cell">
-              <div className="results-header-values">${taxCredit.toLocaleString()}</div>
+              <div className="results-header-values">${Math.round(taxCredit).toLocaleString()}</div>
               <div className="results-header-label">
                 <FormattedMessage id="results.header-taxCredits" defaultMessage="Annual Tax Credit" />
               </div>


### PR DESCRIPTION
What (if anything) did you refactor?
- Updated tax value $ amount to include the comma on results 

<img width="677" alt="Screenshot 2024-03-28 at 11 58 27 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/7133950/ff46a848-7bc8-4065-beed-5954e4f6aafe">
