### PR TITLE
Refactor/income feq help text

### DIFF
--- a/src/Components/IncomeBlock/IncomeQuestion.js
+++ b/src/Components/IncomeBlock/IncomeQuestion.js
@@ -15,6 +15,7 @@ import {
 import incomeOptions from '../../Assets/incomeOptions';
 import frequencyOptions from '../../Assets/frequencyOptions';
 import Textfield from '../Textfield/Textfield';
+import HelpButton from '../HelpBubbleIcon/HelpButton.tsx';
 
 const StyledSelectfield = styled(Select)({
   minWidth: 200,
@@ -325,6 +326,10 @@ const IncomeQuestion = ({
         <h2 className="question-label">
           <FormattedMessage id={formattedMsgId} defaultMessage={formattedMsgDefaultMsg} />
           {getIncomeStreamNameLabel(allIncomeSources[index].incomeStreamName)}
+          <HelpButton
+            helpText='"Every 2 weeks" means you get paid every other week. "Twice a month" means you get paid two times a month on the same dates each month.'
+            helpId="personIncomeBlock.income-freq-help-text"
+          />
         </h2>
         <FormControl sx={{ m: 1, minWidth: 120, maxWidth: '100%' }} error={incomeFrequencyErrorController.showError}>
           <InputLabel id="income-frequency-label">

--- a/src/Components/IncomeBlock/IncomeQuestion.js
+++ b/src/Components/IncomeBlock/IncomeQuestion.js
@@ -332,7 +332,7 @@ const IncomeQuestion = ({
           />
         </h2>
         <FormControl sx={{ m: 1, minWidth: 120, maxWidth: '100%' }} error={incomeFrequencyErrorController.showError}>
-          <InputLabel id="income-frequency-label">
+          <InputLabel id='income-frequency-label'>
             <FormattedMessage
               id="personIncomeBlock.createIncomeStreamFrequencyDropdownMenu-freqLabel"
               defaultMessage="Frequency"


### PR DESCRIPTION
What (if any) features are you implementing?
- Add help text to dropdown income options for “every 2 weeks” and “twice a month”
- Please note that I already added the text to the production's translations admin.
<img width="1389" alt="Screenshot 2024-04-19 at 2 58 18 PM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/4eee6fa1-f87d-40ab-8385-f6fe0413a74d">