### PR TITLE
Feat/accessibility v2

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -88,8 +88,8 @@
   font-size: 1rem;
 }
 
-.sign-up-data-privacy-link {
-  color: var(--primary-color);
+.link-color {
+  color: var(--link-color);
 }
 
 .main-max-width {

--- a/src/App.css
+++ b/src/App.css
@@ -89,7 +89,7 @@
 }
 
 .link-color {
-  color: var(--link-color);
+  color: var(--midBlue-color);
 }
 
 .main-max-width {

--- a/src/Assets/styleController.ts
+++ b/src/Assets/styleController.ts
@@ -23,7 +23,6 @@ export interface ITheme {
     '--icon-color': string;
     '--secondary-icon-color': string;
     '--option-card-hover-font-color': string;
-    '--link-color': string;
   };
 }
 
@@ -56,7 +55,6 @@ const themes: IThemes = {
       '--icon-color': '#D6743F',
       '--secondary-icon-color': '#D6743F',
       '--option-card-hover-font-color': '#1D1C1E',
-      '--link-color': '#41528C',
     },
   },
   twoOneOne: {
@@ -82,7 +80,6 @@ const themes: IThemes = {
       '--icon-color': '#ff443b',
       '--secondary-icon-color': '#005191',
       '--option-card-hover-font-color': '#1D1C1E',
-      '--link-color': '#41528C',
     },
   },
 };

--- a/src/Assets/styleController.ts
+++ b/src/Assets/styleController.ts
@@ -23,6 +23,7 @@ export interface ITheme {
     '--icon-color': string;
     '--secondary-icon-color': string;
     '--option-card-hover-font-color': string;
+    '--link-color': string;
   };
 }
 
@@ -55,6 +56,7 @@ const themes: IThemes = {
       '--icon-color': '#D6743F',
       '--secondary-icon-color': '#D6743F',
       '--option-card-hover-font-color': '#1D1C1E',
+      '--link-color': '#41528C',
     },
   },
   twoOneOne: {
@@ -80,6 +82,7 @@ const themes: IThemes = {
       '--icon-color': '#ff443b',
       '--secondary-icon-color': '#005191',
       '--option-card-hover-font-color': '#1D1C1E',
+      '--link-color': '#41528C',
     },
   },
 };

--- a/src/Components/Confirmation/Confirmation.js
+++ b/src/Components/Confirmation/Confirmation.js
@@ -28,9 +28,8 @@ import { ReactComponent as Resources } from '../../Assets/icons/resources.svg';
 import { ReactComponent as Benefits } from '../../Assets/icons/benefits.svg';
 import { ReactComponent as Immediate } from '../../Assets/icons/immediate.svg';
 import { ReactComponent as Referral } from '../../Assets/icons/referral.svg';
-import './Confirmation.css';
 import PreviousButton from '../PreviousButton/PreviousButton';
-import { House } from '@mui/icons-material';
+import './Confirmation.css';
 
 const Confirmation = () => {
   const { formData } = useContext(Context);
@@ -38,6 +37,15 @@ const Confirmation = () => {
   const navigate = useNavigate();
   const intl = useIntl();
   const locationState = { state: { routedFromConfirmationPg: true } };
+  const editHHMemberAriaLabel = intl.formatMessage({ id: 'editHHMember.ariaText', defaultMessage: 'edit household member' });
+  const editExpensesAriaLabel = intl.formatMessage({ id: 'editExpenses.ariaText', defaultMessage: 'edit expenses' });
+  const editHHSizeAriaLabel = intl.formatMessage({ id: 'editHHSize.ariaText', defaultMessage: 'edit household size' });
+  const editHHAssetsAriaLabel = intl.formatMessage({ id: 'editHHAssets.ariaText', defaultMessage: 'edit household assets' });
+  const editZipcodeAriaLabel = intl.formatMessage({ id: 'editZipcode.ariaText', defaultMessage: 'edit zipcode' });
+  const editReferralSrcAriaLabel = intl.formatMessage({ id: 'editReferralSrc.ariaText', defaultMessage: 'edit referral source' });
+  const editCurrentBensAriaLabel = intl.formatMessage({ id: 'editCurrentBens.ariaText', defaultMessage: 'edit current benefits' });
+  const editImmedNeedsAriaLabel = intl.formatMessage({ id: 'editImmedNeeds.ariaText', defaultMessage: 'edit immediate needs' });
+
 
   const getQuestionUrl = (name) => {
     const stepNumber = getStepNumber(name, formData.immutableReferrer);
@@ -100,10 +108,10 @@ const Confirmation = () => {
           </Grid>
           <Grid item xs={2} display="flex" justifyContent="flex-end">
             <button
-              aria-label="edit household member"
+              aria-label={editHHMemberAriaLabel}
               onClick={() => navigate(getQuestionUrl('householdData') + `/${i + 1}`, locationState)}
             >
-              <Edit className="edit-button" alt="edit-icon" />
+              <Edit className="edit-button" alt="edit icon" />
             </button>
           </Grid>
         </Grid>
@@ -149,8 +157,8 @@ const Confirmation = () => {
           )}
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button aria-label="edit expenses" onClick={() => navigate(getQuestionUrl('hasExpenses'), locationState)}>
-            <Edit className="edit-button" alt="edit-icon" />
+          <button aria-label={editExpensesAriaLabel} onClick={() => navigate(getQuestionUrl('hasExpenses'), locationState)}>
+            <Edit className="edit-button" alt="edit icon" />
           </button>
         </Grid>
       </Grid>
@@ -280,8 +288,8 @@ const Confirmation = () => {
           </article>
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button aria-label="edit household size" onClick={() => navigate(linkTo)}>
-            <Edit className="edit-button" alt="edit-icon" />
+          <button aria-label={editHHSizeAriaLabel} onClick={() => navigate(linkTo)}>
+            <Edit className="edit-button" alt="edit icon" />
           </button>
         </Grid>
       </Grid>
@@ -314,10 +322,10 @@ const Confirmation = () => {
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
           <button
-            aria-label="edit household assets"
+            aria-label={editHHAssetsAriaLabel}
             onClick={() => navigate(getQuestionUrl('householdAssets'), locationState)}
           >
-            <Edit className="edit-button" alt="edit-icon" />
+            <Edit className="edit-button" alt="edit icon" />
           </button>
         </Grid>
       </Grid>
@@ -349,8 +357,8 @@ const Confirmation = () => {
           </p>
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button aria-label="edit zipcode" onClick={() => navigate(getQuestionUrl('zipcode'), locationState)}>
-            <Edit className="edit-button" alt="edit-icon" />
+          <button aria-label={editZipcodeAriaLabel} onClick={() => navigate(getQuestionUrl('zipcode'), locationState)}>
+            <Edit className="edit-button" alt="edit icon" />
           </button>
         </Grid>
       </Grid>
@@ -383,10 +391,10 @@ const Confirmation = () => {
           </Grid>
           <Grid item xs={2} display="flex" justifyContent="flex-end">
             <button
-              aria-label="edit referral source"
+              aria-label={editReferralSrcAriaLabel}
               onClick={() => navigate(getQuestionUrl('referralSource'), locationState)}
             >
-              <Edit className="edit-button" alt="edit-icon" />
+              <Edit className="edit-button" alt="edit icon" />
             </button>
           </Grid>
         </Grid>
@@ -426,7 +434,7 @@ const Confirmation = () => {
           getQuestionUrl('hasBenefits'),
           allBenefitsList,
           <Benefits className="confirmation-icon" alt="benefits-icon" />,
-          'edit current benefits',
+          editCurrentBensAriaLabel,
         )}
         {displayHHCheckboxSection(
           'acuteHHConditions',
@@ -435,6 +443,7 @@ const Confirmation = () => {
           getQuestionUrl('acuteHHConditions'),
           refactorOptionsList(acuteConditionOptions),
           <Immediate className="confirmation-icon" alt="immediate-icon" />,
+          editImmedNeedsAriaLabel,
         )}
         {displayReferralSourceSection()}
       </>
@@ -574,7 +583,7 @@ const Confirmation = () => {
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
           <button aria-label={ariaLabel} onClick={() => navigate(linkTo, locationState)}>
-            <Edit className="edit-button" alt="edit-icon" />
+            <Edit className="edit-button" alt="edit icon" />
           </button>
         </Grid>
       </Grid>

--- a/src/Components/Confirmation/Confirmation.js
+++ b/src/Components/Confirmation/Confirmation.js
@@ -37,15 +37,29 @@ const Confirmation = () => {
   const navigate = useNavigate();
   const intl = useIntl();
   const locationState = { state: { routedFromConfirmationPg: true } };
-  const editHHMemberAriaLabel = intl.formatMessage({ id: 'editHHMember.ariaText', defaultMessage: 'edit household member' });
+  const editHHMemberAriaLabel = intl.formatMessage({
+    id: 'editHHMember.ariaText',
+    defaultMessage: 'edit household member',
+  });
   const editExpensesAriaLabel = intl.formatMessage({ id: 'editExpenses.ariaText', defaultMessage: 'edit expenses' });
   const editHHSizeAriaLabel = intl.formatMessage({ id: 'editHHSize.ariaText', defaultMessage: 'edit household size' });
-  const editHHAssetsAriaLabel = intl.formatMessage({ id: 'editHHAssets.ariaText', defaultMessage: 'edit household assets' });
+  const editHHAssetsAriaLabel = intl.formatMessage({
+    id: 'editHHAssets.ariaText',
+    defaultMessage: 'edit household assets',
+  });
   const editZipcodeAriaLabel = intl.formatMessage({ id: 'editZipcode.ariaText', defaultMessage: 'edit zipcode' });
-  const editReferralSrcAriaLabel = intl.formatMessage({ id: 'editReferralSrc.ariaText', defaultMessage: 'edit referral source' });
-  const editCurrentBensAriaLabel = intl.formatMessage({ id: 'editCurrentBens.ariaText', defaultMessage: 'edit current benefits' });
-  const editImmedNeedsAriaLabel = intl.formatMessage({ id: 'editImmedNeeds.ariaText', defaultMessage: 'edit immediate needs' });
-
+  const editReferralSrcAriaLabel = intl.formatMessage({
+    id: 'editReferralSrc.ariaText',
+    defaultMessage: 'edit referral source',
+  });
+  const editCurrentBensAriaLabel = intl.formatMessage({
+    id: 'editCurrentBens.ariaText',
+    defaultMessage: 'edit current benefits',
+  });
+  const editImmedNeedsAriaLabel = intl.formatMessage({
+    id: 'editImmedNeeds.ariaText',
+    defaultMessage: 'edit immediate needs',
+  });
 
   const getQuestionUrl = (name) => {
     const stepNumber = getStepNumber(name, formData.immutableReferrer);
@@ -157,7 +171,10 @@ const Confirmation = () => {
           )}
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">
-          <button aria-label={editExpensesAriaLabel} onClick={() => navigate(getQuestionUrl('hasExpenses'), locationState)}>
+          <button
+            aria-label={editExpensesAriaLabel}
+            onClick={() => navigate(getQuestionUrl('hasExpenses'), locationState)}
+          >
             <Edit className="edit-button" alt="edit icon" />
           </button>
         </Grid>

--- a/src/Components/EmailResults/EmailResults.tsx
+++ b/src/Components/EmailResults/EmailResults.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@mui/material';
 import Snackbar from '@mui/material/Snackbar';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';

--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -103,12 +103,11 @@ const Header = ({ handleTextfieldChange }) => {
         <Modal open={openShare} onClose={handleCloseShare} aria-labelledby="share-my-friend-ben-modal">
           <Share close={handleCloseShare} id="share-my-friend-ben-modal" />
         </Modal>
-        <Modal open={openEmailResults} onClose={handleCloseEmailResults} aria-labelledby="email-results-modal">
+        <Modal open={openEmailResults} onClose={handleCloseEmailResults} aria-label="save my results modal">
           <EmailResults
             handleTextfieldChange={handleTextfieldChange}
             screenId={screenUUID}
             close={handleCloseEmailResults}
-            id="email-results-modal"
           />
         </Modal>
       </Paper>

--- a/src/Components/HelpBubbleIcon/HelpButton.tsx
+++ b/src/Components/HelpBubbleIcon/HelpButton.tsx
@@ -1,18 +1,19 @@
 import { IconButton } from '@mui/material';
 import { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { ReactComponent as HelpBubble } from '../../Assets/icons/helpBubble.svg';
 
 const HelpButton = ({ className, helpText, helpId }: { className?: string; helpText: string; helpId: string }) => {
+  const intl = useIntl();
   const [showHelpText, setShowHelpText] = useState(false);
-
   const handleClick = () => {
     setShowHelpText((setShow) => !setShow);
   };
+  const translatedAriaLabel = intl.formatMessage({ id: 'helpButton.ariaText', defaultMessage: 'help button' });
 
   return (
     <>
-      <IconButton onClick={handleClick}>
+      <IconButton onClick={handleClick} aria-label={translatedAriaLabel}>
         <HelpBubble style={{ height: '20px', width: '20px' }} />
       </IconButton>
       <p className={`${className} question-description help-text`}>

--- a/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
+++ b/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
@@ -41,7 +41,10 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
   };
   const [submittedCount, setSubmittedCount] = useState(0);
   const intl = useIntl();
-  const editHHMemberAriaLabel = intl.formatMessage({ id: 'editHHMember.ariaText', defaultMessage: 'edit household member' });
+  const editHHMemberAriaLabel = intl.formatMessage({
+    id: 'editHHMember.ariaText',
+    defaultMessage: 'edit household member',
+  });
 
   const initialMemberData = formData.householdData[page - 1] ?? {
     age: '',

--- a/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
+++ b/src/Components/HouseholdDataBlock/HouseholdDataBlock.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useContext } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { Box, IconButton, Stack } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import ContinueButton from '../ContinueButton/ContinueButton';
@@ -24,8 +24,8 @@ import {
 import { getStepNumber } from '../../Assets/stepDirectory';
 import { Context } from '../Wrapper/Wrapper.tsx';
 import { isCustomTypedLocationState } from '../../Types/FormData.ts';
-import './HouseholdDataBlock.css';
 import HelpButton from '../HelpBubbleIcon/HelpButton.tsx';
+import './HouseholdDataBlock.css';
 
 const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
   const { formData } = useContext(Context);
@@ -40,6 +40,8 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
     navigate(`/${uuid}/step-${step}/${page}`);
   };
   const [submittedCount, setSubmittedCount] = useState(0);
+  const intl = useIntl();
+  const editHHMemberAriaLabel = intl.formatMessage({ id: 'editHHMember.ariaText', defaultMessage: 'edit household member' });
 
   const initialMemberData = formData.householdData[page - 1] ?? {
     age: '',
@@ -232,8 +234,8 @@ const HouseholdDataBlock = ({ handleHouseholdDataSubmit }) => {
         <div className="household-member-header">
           <h3 className="member-added-relationship">{relationship}:</h3>
           <div className="household-member-edit-button">
-            <IconButton onClick={handleEditSubmit}>
-              <EditIcon />
+            <IconButton onClick={handleEditSubmit} aria-label={editHHMemberAriaLabel}>
+              <EditIcon alt="edit icon" />
             </IconButton>
           </div>
         </div>

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -150,7 +150,7 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
                 defaultMessage="Some benefits are available to Non-U.S. citizens. Non-U.S. citizens planning to apply for legal permanent residency or a visa should consider how applying for any benefits may affect their immigration status. For more information, please review the "
               />
               <a
-                style={{ color: 'var(--midBlue-color)' }}
+                className='link-color'
                 href="https://cdhs.colorado.gov/public-charge-rule-and-colorado-immigrants#:~:text=About%20public%20charge&text=The%20test%20looks%20at%20whether,affidavit%20of%20support%20or%20contract."
                 target="_blank"
                 onClick={() => {

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -106,18 +106,14 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
           id="disclaimer-label"
           defaultMessage="By proceeding, you confirm that you have read and agree to the "
         />
-        <Link
-          href={getLinksForCheckbox().privacyPolicyLink}
-          target="_blank"
-          sx={{ color: theme.cssVariables['--link-color'] }}
-        >
+        <Link href={getLinksForCheckbox().privacyPolicyLink} target="_blank" sx={{ color: theme.midBlueColor }}>
           <FormattedMessage id="landingPage-policyText" defaultMessage="Privacy Policy" />
         </Link>
         <FormattedMessage id="landingPage-and-text" defaultMessage=" and " />
         <Link
           href={getLinksForCheckbox().addTermsConsentToContact}
           target="_blank"
-          sx={{ color: theme.cssVariables['--link-color'] }}
+          sx={{ color: theme.midBlueColor }}
         >
           <FormattedMessage id="landingPage-additionalTerms" defaultMessage="Additional Terms & Consent to Contact" />
         </Link>
@@ -154,7 +150,7 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
                 defaultMessage="Some benefits are available to Non-U.S. citizens. Non-U.S. citizens planning to apply for legal permanent residency or a visa should consider how applying for any benefits may affect their immigration status. For more information, please review the "
               />
               <a
-                style={{ color: 'var(--link-color)' }}
+                style={{ color: 'var(--midBlue-color)' }}
                 href="https://cdhs.colorado.gov/public-charge-rule-and-colorado-immigrants#:~:text=About%20public%20charge&text=The%20test%20looks%20at%20whether,affidavit%20of%20support%20or%20contract."
                 target="_blank"
                 onClick={() => {

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -106,14 +106,18 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
           id="disclaimer-label"
           defaultMessage="By proceeding, you confirm that you have read and agree to the "
         />
-        <Link href={getLinksForCheckbox().privacyPolicyLink} target="_blank" sx={{ color: theme.secondaryColor }}>
+        <Link
+          href={getLinksForCheckbox().privacyPolicyLink}
+          target="_blank"
+          sx={{ color: theme.cssVariables['--link-color'] }}
+        >
           <FormattedMessage id="landingPage-policyText" defaultMessage="Privacy Policy" />
         </Link>
         <FormattedMessage id="landingPage-and-text" defaultMessage=" and " />
         <Link
           href={getLinksForCheckbox().addTermsConsentToContact}
           target="_blank"
-          sx={{ color: theme.secondaryColor }}
+          sx={{ color: theme.cssVariables['--link-color'] }}
         >
           <FormattedMessage id="landingPage-additionalTerms" defaultMessage="Additional Terms & Consent to Contact" />
         </Link>
@@ -150,7 +154,7 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
                 defaultMessage="Some benefits are available to Non-U.S. citizens. Non-U.S. citizens planning to apply for legal permanent residency or a visa should consider how applying for any benefits may affect their immigration status. For more information, please review the "
               />
               <a
-                style={{ color: 'var(--primary-color)' }}
+                style={{ color: 'var(--link-color)' }}
                 href="https://cdhs.colorado.gov/public-charge-rule-and-colorado-immigrants#:~:text=About%20public%20charge&text=The%20test%20looks%20at%20whether,affidavit%20of%20support%20or%20contract."
                 target="_blank"
                 onClick={() => {

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -150,7 +150,7 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
                 defaultMessage="Some benefits are available to Non-U.S. citizens. Non-U.S. citizens planning to apply for legal permanent residency or a visa should consider how applying for any benefits may affect their immigration status. For more information, please review the "
               />
               <a
-                style={{ color: theme.secondaryColor }}
+                style={{ color: 'var(--primary-color)' }}
                 href="https://cdhs.colorado.gov/public-charge-rule-and-colorado-immigrants#:~:text=About%20public%20charge&text=The%20test%20looks%20at%20whether,affidavit%20of%20support%20or%20contract."
                 target="_blank"
                 onClick={() => {

--- a/src/Components/Results/BackAndSaveButtons/BackAndSaveButtons.tsx
+++ b/src/Components/Results/BackAndSaveButtons/BackAndSaveButtons.tsx
@@ -48,13 +48,11 @@ const BackAndSaveButtons = ({ handleTextfieldChange, navigateToLink, BackToThisP
         </div>
       </button>
       <Modal open={openSaveModal} aria-label="email-text-results-modal">
-        <div>
-          <EmailResults
-            handleTextfieldChange={handleTextfieldChange}
-            screenId={definedScreenerId}
-            close={() => setOpenSaveModal(!openSaveModal)}
-          />
-        </div>
+        <EmailResults
+          handleTextfieldChange={handleTextfieldChange}
+          screenId={definedScreenerId}
+          close={() => setOpenSaveModal(!openSaveModal)}
+        />
       </Modal>
     </div>
   );

--- a/src/Components/Results/BackAndSaveButtons/BackAndSaveButtons.tsx
+++ b/src/Components/Results/BackAndSaveButtons/BackAndSaveButtons.tsx
@@ -47,8 +47,8 @@ const BackAndSaveButtons = ({ handleTextfieldChange, navigateToLink, BackToThisP
           <SaveIcon className="save-icon" />
         </div>
       </button>
-      <Modal open={openSaveModal} aria-labelledby="email-text-results-modal">
-        <div id="email-text-results-modal">
+      <Modal open={openSaveModal} aria-label="email-text-results-modal">
+        <div>
           <EmailResults
             handleTextfieldChange={handleTextfieldChange}
             screenId={definedScreenerId}

--- a/src/Components/Results/BackAndSaveButtons/BackAndSaveButtons.tsx
+++ b/src/Components/Results/BackAndSaveButtons/BackAndSaveButtons.tsx
@@ -48,11 +48,13 @@ const BackAndSaveButtons = ({ handleTextfieldChange, navigateToLink, BackToThisP
         </div>
       </button>
       <Modal open={openSaveModal} aria-labelledby="email-text-results-modal">
-        <EmailResults
-          handleTextfieldChange={handleTextfieldChange}
-          screenId={definedScreenerId}
-          close={() => setOpenSaveModal(!openSaveModal)}
-        />
+        <div id="email-text-results-modal">
+          <EmailResults
+            handleTextfieldChange={handleTextfieldChange}
+            screenId={definedScreenerId}
+            close={() => setOpenSaveModal(!openSaveModal)}
+          />
+        </div>
       </Modal>
     </div>
   );

--- a/src/Components/Results/CategoryHeading/CategoryHeading.tsx
+++ b/src/Components/Results/CategoryHeading/CategoryHeading.tsx
@@ -42,7 +42,7 @@ const CategoryHeading: React.FC<CategoryHeadingProps> = ({ headingType }) => {
     <div>
       <div className="category-heading-container">
         <div className="category-heading-column">
-          <div className="category-heading-icon" aria-label={`${headingType.default_message} icon`} role='img'>
+          <div className="category-heading-icon" aria-label={`${headingType.default_message} icon`} role="img">
             <IconComponent />
           </div>
           <h2 className="category-heading-text-style">

--- a/src/Components/Results/CategoryHeading/CategoryHeading.tsx
+++ b/src/Components/Results/CategoryHeading/CategoryHeading.tsx
@@ -41,7 +41,7 @@ const CategoryHeading: React.FC<CategoryHeadingProps> = ({ headingType }) => {
     <div>
       <div className="category-heading-container">
         <div className="category-heading-column">
-          <div className="category-heading-icon" aria-label={`${headingType.default_message} icon`}>
+          <div className="category-heading-icon" aria-label={`${headingType.default_message} icon`} role='img'>
             <IconComponent />
           </div>
           <h2 className="category-heading-text-style">

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -183,6 +183,7 @@ li.apply-info {
 
 .content-header {
   font-size: 1.25rem;
+  color: var(--secondary-color)
 }
 
 .slim-text {
@@ -192,6 +193,16 @@ li.apply-info {
 .email-link,
 .phone-link {
   text-decoration: none;
+}
+
+.navigator-name {
+  font-family: 'Roboto Slab', serif;
+  font-weight: 700;
+  color: #293457;
+}
+
+.navigator-desc {
+  color: black;
 }
 
 /* TABLET */

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -183,7 +183,7 @@ li.apply-info {
 
 .content-header {
   font-size: 1.25rem;
-  color: var(--secondary-color)
+  color: var(--secondary-color);
 }
 
 .slim-text {

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -118,33 +118,21 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
                     )}
                     {navigator.assistance_link.default_message && (
                       <div>
-                        <a
-                          href={navigator.assistance_link.default_message}
-                          target="_blank"
-                          style={{ color: 'var(--midBlue-color)' }}
-                        >
+                        <a href={navigator.assistance_link.default_message} target="_blank" className="link-color">
                           <FormattedMessage id="results.visit-webiste" defaultMessage="Visit Website" />
                         </a>
                       </div>
                     )}
                     {navigator.email.default_message && (
                       <div>
-                        <a
-                          href={`mailto:${navigator.email}`}
-                          className="email-link"
-                          style={{ color: 'var(--midBlue-color)' }}
-                        >
+                        <a href={`mailto:${navigator.email}`} className="link-color email-link">
                           <ResultsTranslate translation={navigator.email} />
                         </a>
                       </div>
                     )}
                     {navigator.phone_number && (
                       <div>
-                        <a
-                          href={`tel:${navigator.phone_number}`}
-                          className="phone-link"
-                          style={{ color: 'var(--midBlue-color)' }}
-                        >
+                        <a href={`tel:${navigator.phone_number}`} className="link-color phone-link">
                           {navigator.phone_number}
                         </a>
                       </div>

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -96,9 +96,17 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
             <ul className="apply-box-list">
               {program.navigators.map((navigator, index) => (
                 <li key={index} className="apply-info">
-                  {navigator.name && <ResultsTranslate translation={navigator.name} />}
+                  {navigator.name && (
+                    <p className="navigator-name">
+                      <ResultsTranslate translation={navigator.name} />
+                    </p>
+                  )}
                   <div className="address-info">
-                    {navigator.description && <ResultsTranslate translation={navigator.description} />}
+                    {navigator.description && (
+                      <p className="navigator-desc">
+                        <ResultsTranslate translation={navigator.description} />
+                      </p>
+                    )}
                     {navigator.assistance_link.default_message && (
                       <div>
                         <a

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -101,21 +101,33 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
                     {navigator.description && <ResultsTranslate translation={navigator.description} />}
                     {navigator.assistance_link.default_message && (
                       <div>
-                        <a href={navigator.assistance_link.default_message} target="_blank">
+                        <a
+                          href={navigator.assistance_link.default_message}
+                          target="_blank"
+                          style={{ color: 'var(--link-color)' }}
+                        >
                           <FormattedMessage id="results.visit-webiste" defaultMessage="Visit Website" />
                         </a>
                       </div>
                     )}
                     {navigator.email.default_message && (
                       <div>
-                        <a href={`mailto:${navigator.email}`} className="email-link">
+                        <a
+                          href={`mailto:${navigator.email}`}
+                          className="email-link"
+                          style={{ color: 'var(--link-color)' }}
+                        >
                           <ResultsTranslate translation={navigator.email} />
                         </a>
                       </div>
                     )}
                     {navigator.phone_number && (
                       <div>
-                        <a href={`tel:${navigator.phone_number}`} className="phone-link">
+                        <a
+                          href={`tel:${navigator.phone_number}`}
+                          className="phone-link"
+                          style={{ color: 'var(--link-color)' }}
+                        >
                           {navigator.phone_number}
                         </a>
                       </div>

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -121,7 +121,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
                         <a
                           href={navigator.assistance_link.default_message}
                           target="_blank"
-                          style={{ color: 'var(--link-color)' }}
+                          style={{ color: 'var(--midBlue-color)' }}
                         >
                           <FormattedMessage id="results.visit-webiste" defaultMessage="Visit Website" />
                         </a>
@@ -132,7 +132,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
                         <a
                           href={`mailto:${navigator.email}`}
                           className="email-link"
-                          style={{ color: 'var(--link-color)' }}
+                          style={{ color: 'var(--midBlue-color)' }}
                         >
                           <ResultsTranslate translation={navigator.email} />
                         </a>
@@ -143,7 +143,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
                         <a
                           href={`tel:${navigator.phone_number}`}
                           className="phone-link"
-                          style={{ color: 'var(--link-color)' }}
+                          style={{ color: 'var(--midBlue-color)' }}
                         >
                           {navigator.phone_number}
                         </a>

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -69,7 +69,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
   };
 
   return (
-    <article className="program-page-container">
+    <main className="program-page-container">
       <section className="back-to-results-button-container">
         <BackAndSaveButtons
           handleTextfieldChange={() => {}}
@@ -147,7 +147,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
           <ResultsTranslate translation={program.description} />
         </section>
       </div>
-    </article>
+    </main>
   );
 };
 

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -90,9 +90,9 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
       <div className="content-width">
         {program.navigators.length > 0 && (
           <section className="apply-box">
-            <h3 className="content-header">
+            <h2 className="content-header">
               <FormattedMessage id="results.get-help-applying" defaultMessage="Get Help Applying" />
-            </h3>
+            </h2>
             <ul className="apply-box-list">
               {program.navigators.map((navigator, index) => (
                 <li key={index} className="apply-info">

--- a/src/Components/Results/Programs/Filter.css
+++ b/src/Components/Results/Programs/Filter.css
@@ -59,7 +59,7 @@
 }
 
 .filters-container {
-  padding: 0.75rem;
+  padding: 0 0.75rem 0.75rem 0.75rem;
 }
 
 .flex-direction-row {
@@ -75,6 +75,12 @@
 
 .MuiButtonBase-root.MuiCheckbox-root {
   padding: 0 0.5rem;
+}
+
+.filters-close-button {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.25rem 0.75rem;
 }
 
 @media (max-width: 500px), (max-height: 700px) {

--- a/src/Components/Results/Programs/Filter.tsx
+++ b/src/Components/Results/Programs/Filter.tsx
@@ -132,7 +132,11 @@ export const Filter = () => {
       }
     });
 
-    return <section className="filters-container">{filters}</section>;
+    return (
+      <section className="filters-container" id="filter-modal">
+        {filters}
+      </section>
+    );
   };
 
   const displayCitizenshipPopover = () => {
@@ -154,6 +158,7 @@ export const Filter = () => {
             horizontal: 'left',
           }}
           transformOrigin={{ vertical: 2, horizontal: 0 }}
+          aria-labelledby="filter-modal"
         >
           {renderCitizenshipFilters(citizenshipFilterFormControlLabels, filtersChecked)}
         </Popover>

--- a/src/Components/Results/Programs/Filter.tsx
+++ b/src/Components/Results/Programs/Filter.tsx
@@ -8,6 +8,8 @@ import { FormattedMessageType } from '../../../Types/Questions';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import CloseIcon from '@mui/icons-material/Close';
+import IconButton from '@mui/material/IconButton';
 import './Filter.css';
 
 export const Filter = () => {
@@ -133,11 +135,19 @@ export const Filter = () => {
     });
 
     return (
-      <section className="filters-container" id="filter-modal">
+      <section className="filters-container" id="citizenship-filters-modal">
         {filters}
       </section>
     );
   };
+
+  const handleFilterClose = () => {
+     const updatedCitButtonClass = citButtonClass.replace('flat-white-border-bottom', '');
+
+     setCitizenshipPopoverAnchor(null);
+     setCitizenshipFilterIsOpen(false);
+     setCitButtonClass(updatedCitButtonClass);
+  }
 
   const displayCitizenshipPopover = () => {
     return (
@@ -145,21 +155,20 @@ export const Filter = () => {
         <Popover
           id="citizenshipPopover"
           open={Boolean(citizenshipPopoverAnchor)}
-          onClose={() => {
-            const updatedCitButtonClass = citButtonClass.replace('flat-white-border-bottom', '');
-
-            setCitizenshipPopoverAnchor(null);
-            setCitizenshipFilterIsOpen(false);
-            setCitButtonClass(updatedCitButtonClass);
-          }}
+          onClose={handleFilterClose}
           anchorEl={citizenshipPopoverAnchor}
           anchorOrigin={{
             vertical: 'bottom',
             horizontal: 'left',
           }}
           transformOrigin={{ vertical: 2, horizontal: 0 }}
-          aria-labelledby="filter-modal"
+          aria-labelledby="citizenship-filters-modal"
         >
+          <div className='filters-close-button'>
+            <IconButton size="small" aria-label="close citizenship filters" id="close-citizenship-filters-button" color="inherit" onClick={handleFilterClose}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </div>
           {renderCitizenshipFilters(citizenshipFilterFormControlLabels, filtersChecked)}
         </Popover>
       </section>
@@ -169,7 +178,12 @@ export const Filter = () => {
   const displayCitizenshipButton = () => {
     return (
       <section>
-        <Button className={citButtonClass} variant="contained" onClick={(event) => handleCitizenshipBtnClick(event)}>
+        <Button
+          className={citButtonClass}
+          variant="contained"
+          onClick={(event) => handleCitizenshipBtnClick(event)}
+          aria-label="citizenship filters"
+        >
           <FormattedMessage id="filterSection.citizenship" defaultMessage="CITIZENSHIP" />
           {citizenshipFilterIsOpen ? (
             <KeyboardArrowDownIcon className="arrow-margin" />

--- a/src/Components/Results/Programs/Filter.tsx
+++ b/src/Components/Results/Programs/Filter.tsx
@@ -135,7 +135,7 @@ export const Filter = () => {
     });
 
     return (
-      <section className="filters-container" id="citizenship-filters-modal">
+      <section className="filters-container">
         {filters}
       </section>
     );
@@ -162,10 +162,10 @@ export const Filter = () => {
             horizontal: 'left',
           }}
           transformOrigin={{ vertical: 2, horizontal: 0 }}
-          aria-labelledby="citizenship-filters-modal"
+          aria-label="citizenship filters modal"
         >
           <div className='filters-close-button'>
-            <IconButton size="small" aria-label="close citizenship filters" id="close-citizenship-filters-button" color="inherit" onClick={handleFilterClose}>
+            <IconButton size="small" aria-label="close citizenship filters" color="inherit" onClick={handleFilterClose}>
               <CloseIcon fontSize="small" />
             </IconButton>
           </div>

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -87,9 +87,7 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
             <FormattedMessage id="program-card.estimated-savings" defaultMessage="Estimated Savings: " />
           </div>
           <div className="result-program-details-box">
-            <strong>
-              {formatMonthlyValue(program)}
-            </strong>
+            <strong>{formatMonthlyValue(program)}</strong>
           </div>
         </div>
       </div>

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -156,24 +156,26 @@ const Results = ({ type, handleTextfieldChange }: ResultsProps) => {
     return <ResultsError />;
   } else if (programId === undefined && (type === 'program' || type === 'need')) {
     return (
-      <ResultsContext.Provider
-        value={{
-          programs,
-          needs,
-          filtersChecked,
-          setFiltersChecked,
-          missingPrograms,
-        }}
-      >
-        <ResultsHeader type={type} handleTextfieldChange={handleTextfieldChange} />
-        <ResultsTabs />
-        <Grid container sx={{ p: 2 }}>
-          <Grid item xs={12}>
-            {type === 'need' ? <Needs /> : <Programs />}
+      <main>
+        <ResultsContext.Provider
+          value={{
+            programs,
+            needs,
+            filtersChecked,
+            setFiltersChecked,
+            missingPrograms,
+          }}
+        >
+          <ResultsHeader type={type} handleTextfieldChange={handleTextfieldChange} />
+          <ResultsTabs />
+          <Grid container sx={{ p: 2 }}>
+            <Grid item xs={12}>
+              {type === 'need' ? <Needs /> : <Programs />}
+            </Grid>
           </Grid>
-        </Grid>
-        {!is211Co && <HelpButton />}
-      </ResultsContext.Provider>
+          {!is211Co && <HelpButton />}
+        </ResultsContext.Provider>
+      </main>
     );
   }
 

--- a/src/Components/Results/Tabs/Tabs.tsx
+++ b/src/Components/Results/Tabs/Tabs.tsx
@@ -12,13 +12,18 @@ const ResultsTabs = () => {
     <Grid container className="results-tab-container">
       <Grid item xs={6} className="results-tab">
         <NavLink to={`/${uuid}/results/benefits`} className={({ isActive }) => (isActive ? 'active' : '')}>
-          <FormattedMessage id="resultsOptions.longTermBenefits" defaultMessage="Long-Term Benefits " />(
-          {programs.length})
+          <h1 style={{ fontSize: '1rem' }}>
+            <FormattedMessage id="resultsOptions.longTermBenefits" defaultMessage="Long-Term Benefits " />(
+            {programs.length})
+          </h1>
         </NavLink>
       </Grid>
       <Grid item xs={6} className="results-tab">
         <NavLink to={`/${uuid}/results/near-term-needs`} className={({ isActive }) => (isActive ? 'active' : '')}>
-          <FormattedMessage id="resultsOptions.nearTermBenefits" defaultMessage="Near-Term Benefits " />({needs.length})
+          <h1 style={{ fontSize: '1rem' }}>
+            <FormattedMessage id="resultsOptions.nearTermBenefits" defaultMessage="Near-Term Benefits " />(
+            {needs.length})
+          </h1>
         </NavLink>
       </Grid>
     </Grid>

--- a/src/Components/SignUp/SignUp.js
+++ b/src/Components/SignUp/SignUp.js
@@ -149,7 +149,7 @@ const SignUp = ({ handleTextfieldChange, handleCheckboxChange, submitted }) => {
                 defaultMessage="{linkVal}"
                 values={{
                   linkVal: (
-                    <a className="sign-up-data-privacy-link" href={privacyLink} target="_blank">
+                    <a className="link-color" href={privacyLink} target="_blank">
                       <FormattedMessage
                         id="signUp.displayDisclosureSection-consentCheckLink"
                         defaultMessage="data privacy policy "

--- a/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
+++ b/src/Components/TwoOneOneComponents/TwoOneOneHeader/TwoOneOneHeader.js
@@ -197,15 +197,14 @@ const TwoOneOneHeader = ({ handleTextfieldChange }) => {
               {displayHamburgerMenuIcon()}
               {displayHamburgerMenu()}
             </Stack>
-            <Modal open={openShare} onClose={handleCloseShare} aria-labelledby="share-my-friend-ben-modal">
-              <Share close={handleCloseShare} id="share-my-friend-ben-modal" />
+            <Modal open={openShare} onClose={handleCloseShare} aria-label="share my friend ben modal">
+              <Share close={handleCloseShare} />
             </Modal>
-            <Modal open={openEmailResults} onClose={handleCloseEmailResults} aria-labelledby="email-results-modal">
+            <Modal open={openEmailResults} onClose={handleCloseEmailResults} aria-label="save my results modal">
               <EmailResults
                 handleTextfieldChange={handleTextfieldChange}
                 screenId={screenUUID}
                 close={handleCloseEmailResults}
-                id="email-results-modal"
               />
             </Modal>
           </Stack>


### PR DESCRIPTION
What (if any) features are you implementing?
- Resolve all of the accessibility issues with the exception of the landmark issue for the citizenship filters and "Save My Results" components.
- I added a close button to the filters so that all users are able to close out of the component.

Were there any issues that arose?
- Given that our Modal components are positioned absolutely, I was not able to resolve the `All page content should be contained by landmarks` issue for them.

Is there anything that you need from your teammate?
- Please review and let me know if you have any questions or concerns.

Updated citizenship filters with a close button:
<img width="620" alt="Screenshot 2024-05-14 at 11 47 57 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/ade6177b-9755-4904-9165-2d397904321d">
![Screenshot 2024-05-14 at 11 50 01 AM](https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/9437181f-d156-46aa-ba31-70079cf56c1c)

Save my results accessibility issues before and after:
<img width="1728" alt="Screenshot 2024-05-14 at 10 31 16 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/2e8335e3-cb68-4e23-b006-be62cbeeb4a4">
<img width="1728" alt="Screenshot 2024-05-14 at 10 31 33 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/e08914cc-8027-451e-8d08-400634b18200">

Filter accessibility issues before and after:
<img width="1728" alt="Screenshot 2024-05-14 at 10 30 18 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/536582d8-263b-4f9f-af24-4b83c688d0ea">
<img width="1728" alt="Screenshot 2024-05-14 at 10 32 01 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/6208d2a4-e217-452e-a712-afc68a03deb7">
