### PR TITLE
Fix New Benefit Flag Wrap in Other Languages

### DIFF
--- a/src/Components/Results/Programs/ProgramCard.css
+++ b/src/Components/Results/Programs/ProgramCard.css
@@ -55,24 +55,23 @@
   font-weight: bold;
   font-family: 'Roboto Slab', serif;
   background-color: #00b213;
-  padding-left: 0.5rem;
+  padding: 0 0.5rem;
   color: #fff;
-  width: 6rem;
   border-radius: 0 0 0.75rem 0;
   font-size: 0.8125rem;
   position: absolute;
   top: 0;
   left: 0;
   z-index: 100;
+  text-wrap: nowrap;
 }
 
 .low-confidence-flag {
   font-weight: bold;
   font-family: 'Roboto Slab', serif;
   background-color: var(--hover-color);
-  padding-left: 1rem;
+  padding: 0 0.5rem 0 1rem;
   color: var(--primary-color);
-  width: 8rem;
   border-radius: 0 0 0.75rem 0;
   font-size: 0.8125rem;
   position: absolute;

--- a/src/Components/Results/Programs/ProgramCard.css
+++ b/src/Components/Results/Programs/ProgramCard.css
@@ -12,6 +12,14 @@
   border: none;
 }
 
+.result-program-flags-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+}
+
 .result-program-more-info {
   width: 70%;
   display: block;
@@ -59,9 +67,7 @@
   color: #fff;
   border-radius: 0 0 0.75rem 0;
   font-size: 0.8125rem;
-  position: absolute;
   top: 0;
-  left: 0;
   z-index: 100;
   text-wrap: nowrap;
 }
@@ -74,9 +80,7 @@
   color: var(--primary-color);
   border-radius: 0 0 0.75rem 0;
   font-size: 0.8125rem;
-  position: absolute;
   top: 0;
-  left: 5.5rem;
   z-index: 99;
 }
 

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -1,9 +1,11 @@
 import { Link, useParams } from 'react-router-dom';
 import { Program } from '../../../Types/Results';
 import { FormattedMessage } from 'react-intl';
-import { formatMonthlyValue, programValue } from '../FormattedValue';
+import { formatMonthlyValue } from '../FormattedValue';
 import ResultsTranslate from '../Translate/Translate';
 import { useEffect, useRef, useState } from 'react';
+import { useContext } from 'react';
+import { Context } from '../../Wrapper/Wrapper';
 import './ProgramCard.css';
 
 type ProgramCardProps = {
@@ -35,18 +37,18 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
   const isMobile = size < 769 ? true : false;
 
   const newProgramFlagRef = useRef<HTMLDivElement | null>(null);
-  const [leftOffset, setLeftOffset] = useState('0');
   const [newProgramFlagWidth, setNewProgramFlagWidth] = useState<number>(0);
+
+  const { theme } = useContext(Context);
 
   useEffect(() => {
     if (program.new && newProgramFlagRef.current) {
       const width = newProgramFlagRef.current.offsetWidth;
-      const remWidth = width / 16;
-      const paddedWidth = remWidth - 0.5;
+      const fontSize = parseFloat(theme.cssVariables['font-size']);
+      const remWidth = width / fontSize;
       setNewProgramFlagWidth(remWidth);
-      setLeftOffset(`${paddedWidth}rem`);
     }
-  }, [program.new]);
+  }, [program.new, theme.cssVariables['font-size']]);
 
   type ConditonalWrapperProps = {
     children: React.ReactElement;
@@ -57,20 +59,22 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
     condition ? wrapper(children) : children;
   return (
     <div className="result-program-container">
-      {program.new && (
-        <div
-          className="new-program-flag"
-          ref={newProgramFlagRef}
-          style={{ width: newProgramFlagWidth > 0 ? `${newProgramFlagWidth}rem` : 'auto' }}
-        >
-          <FormattedMessage id="results-new-benefit-flag" defaultMessage="New Benefit" />
-        </div>
-      )}
-      {program.low_confidence && (
-        <div className="low-confidence-flag" style={{ left: program.new ? leftOffset : '0' }}>
-          <FormattedMessage id="results-low-confidence-flag" defaultMessage="Low Confidence" />
-        </div>
-      )}
+      <div className="result-program-flags-container">
+        {program.new && (
+          <div
+            className="new-program-flag"
+            ref={newProgramFlagRef}
+            style={{ width: newProgramFlagWidth > 0 ? `${newProgramFlagWidth}rem` : 'auto' }}
+          >
+            <FormattedMessage id="results-new-benefit-flag" defaultMessage="New Benefit" />
+          </div>
+        )}
+        {program.low_confidence && (
+          <div className="low-confidence-flag" style={{ marginLeft: program.new ? '-0.5rem' : '0' }}>
+            <FormattedMessage id="results-low-confidence-flag" defaultMessage="Low Confidence" />
+          </div>
+        )}
+      </div>
       <ConditonalWrapper
         condition={isMobile}
         wrapper={(children) => <div className="result-program-more-info-wrapper">{children}</div>}

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -3,7 +3,7 @@ import { Program } from '../../../Types/Results';
 import { FormattedMessage } from 'react-intl';
 import { formatMonthlyValue } from '../FormattedValue';
 import ResultsTranslate from '../Translate/Translate';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import './ProgramCard.css';
 
 type ProgramCardProps = {

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -3,7 +3,7 @@ import { Program } from '../../../Types/Results';
 import { FormattedMessage } from 'react-intl';
 import { formatMonthlyValue, programValue } from '../FormattedValue';
 import ResultsTranslate from '../Translate/Translate';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import './ProgramCard.css';
 
 type ProgramCardProps = {
@@ -34,6 +34,20 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
 
   const isMobile = size < 769 ? true : false;
 
+  const newProgramFlagRef = useRef<HTMLDivElement | null>(null);
+  const [leftOffset, setLeftOffset] = useState('0');
+  const [newProgramFlagWidth, setNewProgramFlagWidth] = useState<number>(0);
+
+  useEffect(() => {
+    if (program.new && newProgramFlagRef.current) {
+      const width = newProgramFlagRef.current.offsetWidth;
+      const remWidth = width / 16;
+      const paddedWidth = remWidth - 0.5;
+      setNewProgramFlagWidth(remWidth);
+      setLeftOffset(`${paddedWidth}rem`);
+    }
+  }, [program.new]);
+
   type ConditonalWrapperProps = {
     children: React.ReactElement;
     condition: boolean;
@@ -44,12 +58,16 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
   return (
     <div className="result-program-container">
       {program.new && (
-        <div className="new-program-flag">
+        <div
+          className="new-program-flag"
+          ref={newProgramFlagRef}
+          style={{ width: newProgramFlagWidth > 0 ? `${newProgramFlagWidth}rem` : 'auto' }}
+        >
           <FormattedMessage id="results-new-benefit-flag" defaultMessage="New Benefit" />
         </div>
       )}
       {program.low_confidence && (
-        <div className="low-confidence-flag" style={{ left: `${program.new ? '5.5rem' : '0'} ` }}>
+        <div className="low-confidence-flag" style={{ left: program.new ? leftOffset : '0' }}>
           <FormattedMessage id="results-low-confidence-flag" defaultMessage="Low Confidence" />
         </div>
       )}

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -4,8 +4,6 @@ import { FormattedMessage } from 'react-intl';
 import { formatMonthlyValue } from '../FormattedValue';
 import ResultsTranslate from '../Translate/Translate';
 import { useEffect, useRef, useState } from 'react';
-import { useContext } from 'react';
-import { Context } from '../../Wrapper/Wrapper';
 import './ProgramCard.css';
 
 type ProgramCardProps = {
@@ -36,20 +34,6 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
 
   const isMobile = size < 769 ? true : false;
 
-  const newProgramFlagRef = useRef<HTMLDivElement | null>(null);
-  const [newProgramFlagWidth, setNewProgramFlagWidth] = useState<number>(0);
-
-  const { theme } = useContext(Context);
-
-  useEffect(() => {
-    if (program.new && newProgramFlagRef.current) {
-      const width = newProgramFlagRef.current.offsetWidth;
-      const fontSize = parseFloat(theme.cssVariables['font-size']);
-      const remWidth = width / fontSize;
-      setNewProgramFlagWidth(remWidth);
-    }
-  }, [program.new, theme.cssVariables['font-size']]);
-
   type ConditonalWrapperProps = {
     children: React.ReactElement;
     condition: boolean;
@@ -61,11 +45,7 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
     <div className="result-program-container">
       <div className="result-program-flags-container">
         {program.new && (
-          <div
-            className="new-program-flag"
-            ref={newProgramFlagRef}
-            style={{ width: newProgramFlagWidth > 0 ? `${newProgramFlagWidth}rem` : 'auto' }}
-          >
+          <div className="new-program-flag">
             <FormattedMessage id="results-new-benefit-flag" defaultMessage="New Benefit" />
           </div>
         )}


### PR DESCRIPTION
What (if any) features are you implementing?
- Use useRef to get the width of "new benefit" flag, and apply that value to the left offset of "low confidence" flag
What (if anything) did you refactor?
- Updated "new-program-flag" and "low-confidence-flag" css as they both tend to wrap when the text gets too long

- Before
![329005530-ce7a9bb9-40a7-47a2-8f9a-8b4016e3eafa](https://github.com/Gary-Community-Ventures/benefits-calculator/assets/29790405/f2f42327-3545-40d2-8fb7-6b5626329822)


- After in different languages
> <img width="1321" alt="c" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/29790405/669755f9-42a9-4c20-9f1f-9882c83f083b">

> <img width="1333" alt="a" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/29790405/80f8b310-b142-467b-ba3a-a7d2ab63c094">

> <img width="1335" alt="b" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/29790405/6dfb6f1b-24b0-45fe-9595-46b53e706625">
