### PR TITLE
Feat/use category key name

### DIFF
--- a/src/Assets/acuteConditionOptions.tsx
+++ b/src/Assets/acuteConditionOptions.tsx
@@ -27,7 +27,7 @@ export const acuteConditionResultMapping = {
     icon: <Support />,
   },
   childDevelopment: {
-    api_default_message: "Child's Development",
+    api_default_message: "Child's development",
     icon: <Child_development />,
   },
   familyPlanning: {

--- a/src/Components/CurrentBenefits/CurrentBenefits.tsx
+++ b/src/Components/CurrentBenefits/CurrentBenefits.tsx
@@ -209,14 +209,14 @@ const CurrentBenefits = () => {
             <FormattedMessage id="currentBenefits.long-term-benefits" defaultMessage="LONG-TERM BENEFITS" />
             {` (${allLongTermPrograms.length})`}
           </h2>
-          {/* {displayProgramsByCategory(allLongTermPrograms, 'category', groupProgramsIntoCategories)} */}
+          {displayProgramsByCategory(allLongTermPrograms, 'category', groupProgramsIntoCategories)}
         </div>
         <div className="header-and-programs-container">
           <h2 className="long-near-term-header">
             <FormattedMessage id="currentBenefits.near-term-benefits" defaultMessage="NEAR-TERM BENEFITS" />
             {` (${allNearTermPrograms.length})`}
           </h2>
-          {/* {displayProgramsByCategory(allNearTermPrograms, 'type', groupProgramsIntoCategories)} */}
+          {displayProgramsByCategory(allNearTermPrograms, 'type', groupProgramsIntoCategories)}
         </div>
       </main>
     );

--- a/src/Components/CurrentBenefits/CurrentBenefits.tsx
+++ b/src/Components/CurrentBenefits/CurrentBenefits.tsx
@@ -103,11 +103,11 @@ const CurrentBenefits = () => {
   const intl = useIntl();
 
   useEffect(() => {
-    getAllLongTermPrograms().then((programs:Program[]) => {
+    getAllLongTermPrograms().then((programs: Program[]) => {
       setAllLongTermPrograms(programs);
     });
 
-    getAllNearTermPrograms().then((programs:Program[]) => {
+    getAllNearTermPrograms().then((programs: Program[]) => {
       setAllNearTermPrograms(programs);
     });
   }, []);

--- a/src/Components/CurrentBenefits/CurrentBenefits.tsx
+++ b/src/Components/CurrentBenefits/CurrentBenefits.tsx
@@ -103,12 +103,12 @@ const CurrentBenefits = () => {
   const intl = useIntl();
 
   useEffect(() => {
-    getAllLongTermPrograms().then((response) => {
-      setAllLongTermPrograms(response);
+    getAllLongTermPrograms().then((programs:Program[]) => {
+      setAllLongTermPrograms(programs);
     });
 
-    getAllNearTermPrograms().then((response) => {
-      setAllNearTermPrograms(response);
+    getAllNearTermPrograms().then((programs:Program[]) => {
+      setAllNearTermPrograms(programs);
     });
   }, []);
 
@@ -209,14 +209,14 @@ const CurrentBenefits = () => {
             <FormattedMessage id="currentBenefits.long-term-benefits" defaultMessage="LONG-TERM BENEFITS" />
             {` (${allLongTermPrograms.length})`}
           </h2>
-          {displayProgramsByCategory(allLongTermPrograms, 'category', groupProgramsIntoCategories)}
+          {/* {displayProgramsByCategory(allLongTermPrograms, 'category', groupProgramsIntoCategories)} */}
         </div>
         <div className="header-and-programs-container">
           <h2 className="long-near-term-header">
             <FormattedMessage id="currentBenefits.near-term-benefits" defaultMessage="NEAR-TERM BENEFITS" />
             {` (${allNearTermPrograms.length})`}
           </h2>
-          {displayProgramsByCategory(allNearTermPrograms, 'type', groupProgramsIntoCategories)}
+          {/* {displayProgramsByCategory(allNearTermPrograms, 'type', groupProgramsIntoCategories)} */}
         </div>
       </main>
     );

--- a/src/Components/Results/Translate/Translate.tsx
+++ b/src/Components/Results/Translate/Translate.tsx
@@ -1,11 +1,11 @@
 import { FormattedMessage } from 'react-intl';
 import { Translation } from '../../../Types/Results';
 
-type TransalteProps = {
+type TranslateProps = {
   translation: Translation;
 };
 
-const ResultsTranslate = ({ translation }: TransalteProps) => {
+const ResultsTranslate = ({ translation }: TranslateProps) => {
   return <FormattedMessage id={translation.label} defaultMessage={translation.default_message} />;
 };
 

--- a/src/Types/ApiProgramCategories.ts
+++ b/src/Types/ApiProgramCategories.ts
@@ -44,17 +44,12 @@ const findClosestMatchingDefaultMessage = (defaultMessage: string): string => {
   // is the default message perfect?
   if (programTemplateCategories.includes(defaultMessage)) {
     return defaultMessage;
-  };
-
+  }
 
   const normalizedDefaultMessage = normalizeDefaultMessage(defaultMessage);
-  // if not, we normalize the programTemplate categories first
-  //then find where in that array it matches with the normalizedDefaultMessage
-  //and return the value at that
   const maybeTheRightCategory = programTemplateCategories.find((programTemplate) => {
     return normalizeDefaultMessage(programTemplate) === normalizedDefaultMessage;
   });
-
 
   // is the default message invalid because of whitespace, commas, apostrophes, or hyphens?
   if (maybeTheRightCategory) {
@@ -62,10 +57,12 @@ const findClosestMatchingDefaultMessage = (defaultMessage: string): string => {
   } else {
     // is the default message invalid because it uses different wordings
     // or does it have typos not related to whitespace, comma, apostrophe, or hyphen characters?
-    const maybeClosestMatchingCategory = alternateProgramTemplateCategories.find((programTemplate) => programTemplate.previousNormalizedValues.includes(normalizedDefaultMessage));
+    const maybeClosestMatchingCategory = alternateProgramTemplateCategories.find((programTemplate) =>
+      programTemplate.previousNormalizedValues.includes(normalizedDefaultMessage),
+    );
 
     if (!maybeClosestMatchingCategory) {
-      throw new Error(`CategoryName is undefined`)
+      throw new Error(`CategoryName is undefined`);
     }
     return maybeClosestMatchingCategory.correctValue;
   }

--- a/src/Types/ApiProgramCategories.ts
+++ b/src/Types/ApiProgramCategories.ts
@@ -1,0 +1,18 @@
+export const programTemplateCategories = [
+  'Housing and Utilities',
+  'Food and Nutrition',
+  'Health Care',
+  'Transportation',
+  'Tax Credits',
+  'Cash Assistance',
+  'Child Care, Youth, and Education',
+  'Food or Groceries',
+  'Baby Supplies',
+  'Managing housing costs',
+  'Behavioral health',
+  "Child's development",
+  'Family planning',
+  'Job resources',
+  'Low-cost dental care',
+  'Civil legal needs',
+];

--- a/src/Types/ApiProgramCategories.ts
+++ b/src/Types/ApiProgramCategories.ts
@@ -31,3 +31,9 @@ const alternateProgramTemplateCategories = [
     correctValue: 'Job resources'
   },
 ];
+
+const normalizeDefaultMessage = (defaultMessage: string): string => {
+    const whiteSpaceCommasApostropheOrHyphenMinusRegex = /\s|,|'|-/g;
+    return defaultMessage.toLowerCase()
+      .replaceAll(whiteSpaceCommasApostropheOrHyphenMinusRegex, '');
+};

--- a/src/Types/ApiProgramCategories.ts
+++ b/src/Types/ApiProgramCategories.ts
@@ -1,3 +1,5 @@
+import { Translation } from "./Results";
+
 export const programTemplateCategories = [
   'Housing and Utilities',
   'Food and Nutrition',
@@ -67,4 +69,13 @@ const findClosestMatchingDefaultMessage = (defaultMessage: string): string => {
     }
     return maybeClosestMatchingCategory.correctValue;
   }
+};
+
+export const cleanTranslationDefaultMessage = (translation: Translation) => {
+  const cleanDefaultMessage = findClosestMatchingDefaultMessage(translation.default_message);
+
+  return {
+    default_message: cleanDefaultMessage,
+    label: translation.label,
+  };
 };

--- a/src/Types/ApiProgramCategories.ts
+++ b/src/Types/ApiProgramCategories.ts
@@ -16,3 +16,18 @@ export const programTemplateCategories = [
   'Low-cost dental care',
   'Civil legal needs',
 ];
+
+const alternateProgramTemplateCategories = [
+  {
+    previousNormalizedValues: ['diapers'],
+    correctValue: 'Baby Supplies'
+  },
+ {
+    previousNormalizedValues: ['housing'],
+    correctValue: 'Managing housing costs'
+  },
+ {
+    previousNormalizedValues:['jobtraining'],
+    correctValue: 'Job resources'
+  },
+];

--- a/src/Types/ApiProgramCategories.ts
+++ b/src/Types/ApiProgramCategories.ts
@@ -37,3 +37,34 @@ const normalizeDefaultMessage = (defaultMessage: string): string => {
     return defaultMessage.toLowerCase()
       .replaceAll(whiteSpaceCommasApostropheOrHyphenMinusRegex, '');
 };
+
+const findClosestMatchingDefaultMessage = (defaultMessage: string): string => {
+  // is the default message perfect?
+  if (programTemplateCategories.includes(defaultMessage)) {
+    return defaultMessage;
+  };
+
+
+  const normalizedDefaultMessage = normalizeDefaultMessage(defaultMessage);
+  // if not, we normalize the programTemplate categories first
+  //then find where in that array it matches with the normalizedDefaultMessage
+  //and return the value at that
+  const maybeTheRightCategory = programTemplateCategories.find((programTemplate) => {
+    return normalizeDefaultMessage(programTemplate) === normalizedDefaultMessage;
+  });
+
+
+  // is the default message invalid because of whitespace, commas, apostrophes, or hyphens?
+  if (maybeTheRightCategory) {
+    return maybeTheRightCategory;
+  } else {
+    // is the default message invalid because it uses different wordings
+    // or does it have typos not related to whitespace, comma, apostrophe, or hyphen characters?
+    const maybeClosestMatchingCategory = alternateProgramTemplateCategories.find((programTemplate) => programTemplate.previousNormalizedValues.includes(normalizedDefaultMessage));
+
+    if (!maybeClosestMatchingCategory) {
+      throw new Error(`CategoryName is undefined`)
+    }
+    return maybeClosestMatchingCategory.correctValue;
+  }
+};

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -131,8 +131,15 @@ const getAllLongTermPrograms = async () => {
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`);
   }
-  return await response.json();
-};
+
+  const programs = await response.json();
+  const programsWithNormalizedCategoryTranslations = programs.map(program => {
+    const categoryWithNormalizedDefaultMessage = cleanTranslationDefaultMessage(program.category);
+    return { ...program, category: categoryWithNormalizedDefaultMessage };
+  });
+
+  return programsWithNormalizedCategoryTranslations;
+}
 
 const getAllNearTermPrograms = async () => {
   const response = await fetch(apiUrgentNeedsEndpoint, {

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -149,7 +149,14 @@ const getAllNearTermPrograms = async () => {
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`);
   }
-  return await response.json();
+
+  const programs = await response.json();
+  const programsWithNormalizedCategoryTranslations = programs.map(program => {
+    const categoryWithNormalizedDefaultMessage = cleanTranslationDefaultMessage(program.type);
+    return { ...program, type: categoryWithNormalizedDefaultMessage };
+  });
+
+  return programsWithNormalizedCategoryTranslations;
 };
 
 export {

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,4 +1,4 @@
-import { cleanTranslationDefaultMessage } from './Types/ApiProgramCategories';
+import { cleanTranslationDefaultMessage } from './cleanAPICategoryTranslation';
 
 const apiKey = 'Token ' + process.env.REACT_APP_API_KEY;
 const domain = process.env.REACT_APP_DOMAIN_URL;
@@ -133,13 +133,13 @@ const getAllLongTermPrograms = async () => {
   }
 
   const programs = await response.json();
-  const programsWithNormalizedCategoryTranslations = programs.map(program => {
+  const programsWithNormalizedCategoryTranslations = programs.map((program) => {
     const categoryWithNormalizedDefaultMessage = cleanTranslationDefaultMessage(program.category);
     return { ...program, category: categoryWithNormalizedDefaultMessage };
   });
 
   return programsWithNormalizedCategoryTranslations;
-}
+};
 
 const getAllNearTermPrograms = async () => {
   const response = await fetch(apiUrgentNeedsEndpoint, {
@@ -151,7 +151,7 @@ const getAllNearTermPrograms = async () => {
   }
 
   const programs = await response.json();
-  const programsWithNormalizedCategoryTranslations = programs.map(program => {
+  const programsWithNormalizedCategoryTranslations = programs.map((program) => {
     const categoryWithNormalizedDefaultMessage = cleanTranslationDefaultMessage(program.type);
     return { ...program, type: categoryWithNormalizedDefaultMessage };
   });

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,3 +1,5 @@
+import { cleanTranslationDefaultMessage } from './Types/ApiProgramCategories';
+
 const apiKey = 'Token ' + process.env.REACT_APP_API_KEY;
 const domain = process.env.REACT_APP_DOMAIN_URL;
 

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -151,12 +151,12 @@ const getAllNearTermPrograms = async () => {
   }
 
   const programs = await response.json();
-  const programsWithNormalizedCategoryTranslations = programs.map((program) => {
+  const programsWithNormalizedTypeTranslations = programs.map((program) => {
     const categoryWithNormalizedDefaultMessage = cleanTranslationDefaultMessage(program.type);
     return { ...program, type: categoryWithNormalizedDefaultMessage };
   });
 
-  return programsWithNormalizedCategoryTranslations;
+  return programsWithNormalizedTypeTranslations;
 };
 
 export {

--- a/src/cleanAPICategoryTranslation.ts
+++ b/src/cleanAPICategoryTranslation.ts
@@ -35,8 +35,8 @@ const alternateProgramTemplateCategories = [
 ];
 
 const normalizeDefaultMessage = (defaultMessage: string): string => {
-  const whiteSpaceCommasApostropheOrHyphenMinusRegex = /\s|,|'|-/g;
-  return defaultMessage.toLowerCase().replaceAll(whiteSpaceCommasApostropheOrHyphenMinusRegex, '');
+  const whiteSpaceCommasApostropheHyphenMinusNumbersRegex = /\s|,|'|-|[0-9]/g;
+  return defaultMessage.toLowerCase().replaceAll(whiteSpaceCommasApostropheHyphenMinusNumbersRegex, '');
 };
 
 const findClosestMatchingDefaultMessage = (defaultMessage: string): string => {
@@ -50,12 +50,13 @@ const findClosestMatchingDefaultMessage = (defaultMessage: string): string => {
     return normalizeDefaultMessage(programTemplate) === normalizedDefaultMessage;
   });
 
-  // is the default message invalid because of whitespace, commas, apostrophes, or hyphens?
+  // is the default message invalid because of typos related to whitespace, comma, apostrophe,
+  // hyphen or number characters?
   if (maybeTheRightCategory) {
     return maybeTheRightCategory;
   } else {
     // is the default message invalid because it uses different wordings
-    // or does it have typos not related to whitespace, comma, apostrophe, or hyphen characters?
+    // or does it have typos not related to whitespace, comma, apostrophe, hyphen or number characters?
     const maybeClosestMatchingCategory = alternateProgramTemplateCategories.find((programTemplate) =>
       programTemplate.previousNormalizedValues.includes(normalizedDefaultMessage),
     );

--- a/src/cleanAPICategoryTranslation.ts
+++ b/src/cleanAPICategoryTranslation.ts
@@ -1,4 +1,4 @@
-import { Translation } from "./Results";
+import { Translation } from './Types/Results';
 
 export const programTemplateCategories = [
   'Housing and Utilities',
@@ -22,22 +22,21 @@ export const programTemplateCategories = [
 const alternateProgramTemplateCategories = [
   {
     previousNormalizedValues: ['diapers'],
-    correctValue: 'Baby Supplies'
+    correctValue: 'Baby Supplies',
   },
- {
+  {
     previousNormalizedValues: ['housing'],
-    correctValue: 'Managing housing costs'
+    correctValue: 'Managing housing costs',
   },
- {
-    previousNormalizedValues:['jobtraining'],
-    correctValue: 'Job resources'
+  {
+    previousNormalizedValues: ['jobtraining'],
+    correctValue: 'Job resources',
   },
 ];
 
 const normalizeDefaultMessage = (defaultMessage: string): string => {
-    const whiteSpaceCommasApostropheOrHyphenMinusRegex = /\s|,|'|-/g;
-    return defaultMessage.toLowerCase()
-      .replaceAll(whiteSpaceCommasApostropheOrHyphenMinusRegex, '');
+  const whiteSpaceCommasApostropheOrHyphenMinusRegex = /\s|,|'|-/g;
+  return defaultMessage.toLowerCase().replaceAll(whiteSpaceCommasApostropheOrHyphenMinusRegex, '');
 };
 
 const findClosestMatchingDefaultMessage = (defaultMessage: string): string => {


### PR DESCRIPTION
What (if any) features are you implementing?
- I implemented a way to have the program `category` and `type` fields be normalized and return the correct string value or throw an error if it is `undefined`. This will help us resolve issues that have come up whenever the `category` or `type`'s `defaultMessage` string is incompatible with what we have hardcoded in our repo for category/type values.

Were there any issues that arose?
- As I tested out this PR by changing one of the program's `category.name` in admin and refreshing the page I discovered that the real problem lies in the `translations` app since it still uses the translation `id` value to obtain the string value (which may be incorrectly typed in admin) that we see on the front end and only uses the `default_message` field (which is what I changed on this PR) as a fallback:

<img width="1728" alt="Screenshot 2024-06-12 at 11 04 36 AM" src="https://github.com/Gary-Community-Ventures/benefits-calculator/assets/86989161/6c9ab962-6fd9-479e-ac4f-b61b9b7e95c0">
