### PR TITLE
Empty messages are showing up as the label

### DIFF
--- a/src/Components/Confirmation/Confirmation.js
+++ b/src/Components/Confirmation/Confirmation.js
@@ -288,7 +288,7 @@ const Confirmation = () => {
               <FormattedMessage id="questions.householdSize-inputLabel" defaultMessage="Household Size" />
               {': '}
             </b>
-            {useTranslateNumber(householdSize)} {householdSizeDescriptor}
+            {translateNumber(householdSize)} {householdSizeDescriptor}
           </article>
         </Grid>
         <Grid item xs={2} display="flex" justifyContent="flex-end">

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -151,7 +151,7 @@ const LandingPage = ({ handleCheckboxChange }: LandingPageProps) => {
                   defaultMessage="Colorado Department of Human Services Public Charge Rule"
                 />
               </a>
-              <FormattedMessage id="landingPage.publicCharge.afterLink" defaultMessage="" />.
+              <FormattedMessage id="landingPage.publicCharge.afterLink" defaultMessage="." />
             </div>
           </li>
         </ul>

--- a/src/Components/SignUp/SignUp.js
+++ b/src/Components/SignUp/SignUp.js
@@ -165,12 +165,12 @@ const SignUp = ({ handleTextfieldChange, handleCheckboxChange, submitted }) => {
                 values={{
                   linkVal: (
                     <a className="link-color" href={consentToContactLink} target="_blank">
-                      <FormattedMessage id="signUp.consentToContact" defaultMessage=" consent to contact." />
+                      <FormattedMessage id="signUp.consentToContact" defaultMessage=" consent to contact" />
                     </a>
                   ),
                 }}
               />
-              <FormattedMessage id="signUp.consentToContact5" defaultMessage="" />
+              <FormattedMessage id="signUp.consentToContact5" defaultMessage="." />
             </div>
           }
         />


### PR DESCRIPTION
What (if anything) did you refactor?
- Move period into last default message on sign up and landing page.
- Add household size number back to confirmation page.
