### PR TITLE
Bug fix for the progress bar steps not updating

### DIFF
--- a/src/Assets/languageOptions.tsx
+++ b/src/Assets/languageOptions.tsx
@@ -36,7 +36,7 @@ export function useReorderLanguage(text: ReactNode[], order: { [key in Language]
     }
 
     return localeText;
-  }, [locale]);
+  }, [locale, order]);
 }
 
 export function translateNumber(number: number | string, locale: Language) {


### PR DESCRIPTION
What (if anything) did you refactor?
- The step values in the screener UI was not incrementing or decrementing when the user was moving between pages. The `order` parameter was needed to be passed in the `useMemo` hook's dependency array in the `useReorderLanguage` function in order for the step values passed as part of the argument in this function to be also updated after each render.
