### PR TITLE
Add a Spanish Available flag

### DIFF
--- a/src/Assets/languageOptions.tsx
+++ b/src/Assets/languageOptions.tsx
@@ -4,7 +4,7 @@ import { ReactNode, useContext, useMemo } from 'react';
 import { Context } from '../Components/Wrapper/Wrapper';
 
 export type Language = 'en-us' | 'es' | 'vi' | 'fr' | 'am' | 'so' | 'ru' | 'ne' | 'my' | 'zh' | 'ar';
-const languageOptions: Record<Language, string> = {
+export const languageOptions: Record<Language, string> = {
   'en-us': 'English',
   es: 'Español',
   vi: 'Tiếng Việt',

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -204,16 +204,20 @@ li.apply-info {
   color: black;
 }
 
-.navigator-spanish-flag {
+.navigator-lang-flag {
   align-items: center;
   background-color: #e9f8e5;
   display: flex;
   font-size: 0.8rem;
   font-weight: 500;
-  height: 0.5rem;
   justify-content: start;
   padding: 1rem;
-  width: 8.75rem;
+  width: fit-content;
+}
+
+.navigator-langs-container {
+  display: flex;
+  gap: 0.5rem;
 }
 
 /* TABLET */

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -204,6 +204,18 @@ li.apply-info {
   color: black;
 }
 
+.navigator-spanish-flag {
+  align-items: center;
+  background-color: #e9f8e5;
+  display: flex;
+  font-size: 0.8rem;
+  font-weight: 500;
+  height: 0.5rem;
+  justify-content: start;
+  padding: 1rem;
+  width: 8.75rem;
+}
+
 /* TABLET */
 @media (max-width: 775px) {
   .program-icon-and-header {

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -211,7 +211,7 @@ li.apply-info {
   font-size: 0.8rem;
   font-weight: 500;
   justify-content: start;
-  padding: 1rem;
+  padding: 0.5rem 1rem;
   width: fit-content;
 }
 

--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -218,6 +218,7 @@ li.apply-info {
 .navigator-langs-container {
   display: flex;
   gap: 0.5rem;
+  margin: 0.25rem 0;
 }
 
 /* TABLET */

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -71,6 +71,14 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
     );
   };
 
+  const displaySpanishFlag = () => {
+    return (
+      <p className="navigator-spanish-flag">
+        <FormattedMessage id="programPage.nav-spanish" defaultMessage="Spanish Available" />
+      </p>
+    );
+  }
+
   return (
     <main className="program-page-container">
       <section className="back-to-results-button-container">
@@ -113,6 +121,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
                       <ResultsTranslate translation={navigator.name} />
                     </p>
                   )}
+                  {navigator.languages.includes("es") && (displaySpanishFlag())}
                   <div className="address-info">
                     {navigator.description && (
                       <p className="navigator-desc">

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -9,6 +9,7 @@ import './ProgramPage.css';
 import WarningMessage from '../../WarningComponent/WarningMessage.tsx';
 import { useContext } from 'react';
 import { Context } from '../../Wrapper/Wrapper';
+import { languageOptions, Language } from '../../../Assets/languageOptions.tsx';
 
 type ProgramPageProps = {
   program: Program;
@@ -71,11 +72,18 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
     );
   };
 
-  const displaySpanishFlag = () => {
+  const displayLanguageFlags = (navigatorLanguages: Language[]) => {
     return (
-      <p className="navigator-spanish-flag">
-        <FormattedMessage id="programPage.nav-spanish" defaultMessage="Spanish Available" />
-      </p>
+      <div className="navigator-langs-container">
+        {navigatorLanguages.map((lang) => {
+          return (
+            <p className="navigator-lang-flag" key={lang}>
+              {languageOptions[lang]}
+              <FormattedMessage id="programPage.lang-available" defaultMessage=" Available" />
+            </p>
+          );
+        })}
+      </div>
     );
   };
 
@@ -121,7 +129,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
                       <ResultsTranslate translation={navigator.name} />
                     </p>
                   )}
-                  {navigator.languages.includes('es') && displaySpanishFlag()}
+                  {navigator.languages && displayLanguageFlags(navigator.languages)}
                   <div className="address-info">
                     {navigator.description && (
                       <p className="navigator-desc">

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -77,7 +77,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
         <FormattedMessage id="programPage.nav-spanish" defaultMessage="Spanish Available" />
       </p>
     );
-  }
+  };
 
   return (
     <main className="program-page-container">
@@ -121,7 +121,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
                       <ResultsTranslate translation={navigator.name} />
                     </p>
                   )}
-                  {navigator.languages.includes("es") && (displaySpanishFlag())}
+                  {navigator.languages.includes('es') && displaySpanishFlag()}
                   <div className="address-info">
                     {navigator.description && (
                       <p className="navigator-desc">


### PR DESCRIPTION
What (if any) features are you implementing?
- I added a `Spanish Available` flag to the `ProgramPage`. Please note that the contrast checker did not indicate that there were issues with this shade of green although it will still be inaccessible to people who are red/green color blind.
<img width="1727" alt="Screenshot 2024-08-05 at 2 56 59 PM" src="https://github.com/user-attachments/assets/fab5022e-8b60-4b93-8236-a048657d4d9d">
<img width="580" alt="Screenshot 2024-08-05 at 2 56 46 PM" src="https://github.com/user-attachments/assets/b2765c7c-3de9-4e00-b896-ede0fd384a81">
