### PR TITLE
Moved footer data to config.

### DIFF
--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -2,11 +2,14 @@ import Paper from '@mui/material/Paper';
 import Share from '../Share/Share';
 import { useContext } from 'react';
 import { Context } from '../Wrapper/Wrapper';
+import { useConfig } from '../Config/configHook.tsx';
 import { FormattedMessage } from 'react-intl';
 import './Footer.css';
 import { useLogo } from '../Referrer/useLogo';
 
 const Footer = () => {
+  const footerData = useConfig('footer_data');
+  const { address_one, address_two, city, state, zip_code, email, privacy_policy_link } = footerData;
   const context = useContext(Context);
   const { theme } = context;
   return (
@@ -15,15 +18,17 @@ const Footer = () => {
         <div className="footer-content-container">
           <div>
             {useLogo('logoFooterSource', 'logoFooterAlt', 'logo footer-logo')}
-            <p className="white-font">1705 17th St.</p>
-            <p className="white-font">Suite 200</p>
-            <p className="white-font">Denver, CO 80202</p>
+            <p className="white-font">{address_one}</p>
+            <p className="white-font">{address_two}</p>
+            <p className="white-font">
+              {city}, {state} {zip_code}
+            </p>
             <div className="bottom-top-margin">
               <p className="white-font italicized">
                 <FormattedMessage id="footer-questions" defaultMessage="Questions? Contact" />
               </p>
-              <a href="mailto:myfriendben@garycommunity.org" className="white-font italicized footer-link">
-                myfriendben@garycommunity.org
+              <a href={`mailto:${email}`} className="white-font italicized footer-link">
+                {email}
               </a>
             </div>
           </div>
@@ -32,7 +37,7 @@ const Footer = () => {
           </div>
         </div>
         <div className="footer-policy-container">
-          <a href="https://co.myfriendben.org/en/data-privacy-policy" target="_blank" className="policy-link">
+          <a href={privacy_policy_link} target="_blank" className="policy-link">
             <FormattedMessage id="footer.privacyPolicy" defaultMessage="Privacy Policy" />
           </a>
         </div>


### PR DESCRIPTION
What (if anything) did you refactor?
- Footer address, email, and privacy info url moved to config. These will be different for NC.
Any other comments, questions, or concerns?
- `footer_data` config data added to backend.

`{
  "address_one": "1705 17th St.",
  "address_two": "Suite 200",
  "city": "Denver",
  "state": "CO",
  "address_three": "Denver, CO 80202",
  "email": "myfriendben@garycommunity.org",
  "privacy_policy_lilnk": "https://co.myfriendben.org/en/data-privacy-policy"
}`