### PR TITLE
Fix the benefits error not showing up when you go back to current benefits page.

### DIFF
--- a/src/Components/AccordionsContainer/AccordionsContainer.tsx
+++ b/src/Components/AccordionsContainer/AccordionsContainer.tsx
@@ -55,7 +55,7 @@ const AccordionsContainer = ({ componentDetails, submitted }: Props) => {
 
   useEffect(() => {
     errorController.updateError(formData.hasBenefits, formData);
-  }, [expanded]);
+  }, [formData.hasBenefits, formData.benefits]);
 
   const createAccordions = (accordionsInfo: BenefitAccordion[]) => {
     const categoryAccordions = accordionsInfo.map((accordionData, index) => {


### PR DESCRIPTION
What (if anything) did you refactor?
- Change `errorController.updateError` `useEffect` dependencies on for current benefits page.