### PR TITLE
Remove multiple tax unit from results type

### DIFF
--- a/src/Types/Results.ts
+++ b/src/Types/Results.ts
@@ -43,7 +43,6 @@ export type Program = {
   low_confidence: boolean;
   navigators: ProgramNavigator[];
   documents: Translation[];
-  multiple_tax_units: boolean;
   warning_messages: Translation[];
 };
 


### PR DESCRIPTION
What (if anything) did you refactor?
- Remove the multiple tax units from the results type.