### PR TITLE
Document Links

### DIFF
--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -168,6 +168,10 @@ li.apply-info {
   font-family: 'Open Sans', sans-serif;
 }
 
+.required-docs-link {
+  padding-left: 0.25rem;
+}
+
 .program-description {
   margin-bottom: 2rem;
   font-size: 1rem;

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -223,7 +223,14 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
             <ul className="required-docs-list">
               {program.documents.map((document, index) => (
                 <li key={index}>
-                  <ResultsTranslate translation={document} />
+                  <ResultsTranslate translation={document.text} />
+                  {document.link && (
+                      <div>
+                        <a href={document.link.default_message} target="_blank" className="link-color">
+                          <ResultsTranslate translation={document.link_text} />
+                        </a>
+                      </div>
+                    )}
                 </li>
               ))}
             </ul>

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -237,13 +237,13 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
             <ul className="required-docs-list">
               {program.documents.map((document, index) => (
                 <li key={index}>
-                  <ResultsTranslate translation={document.text} />
-                  {document.link && (
-                      <div>
+                  {<ResultsTranslate translation={document.text} />}
+                  {document.link && document.link_text && (
+                      <span className="required-docs-link">
                         <a href={document.link.default_message} target="_blank" className="link-color">
                           <ResultsTranslate translation={document.link_text} />
                         </a>
-                      </div>
+                      </span>
                     )}
                 </li>
               ))}

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -238,7 +238,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
               {program.documents.map((document, index) => (
                 <li key={index}>
                   {<ResultsTranslate translation={document.text} />}
-                  {document.link_url && document.link_text && (
+                  {document.link_url.default_message && document.link_text.default_message && (
                       <span className="required-docs-link">
                         <a href={document.link_url.default_message} target="_blank" className="link-color">
                           <ResultsTranslate translation={document.link_text} />

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -238,9 +238,9 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
               {program.documents.map((document, index) => (
                 <li key={index}>
                   {<ResultsTranslate translation={document.text} />}
-                  {document.link && document.link_text && (
+                  {document.link_url && document.link_text && (
                       <span className="required-docs-link">
-                        <a href={document.link.default_message} target="_blank" className="link-color">
+                        <a href={document.link_url.default_message} target="_blank" className="link-color">
                           <ResultsTranslate translation={document.link_text} />
                         </a>
                       </span>

--- a/src/Types/Results.ts
+++ b/src/Types/Results.ts
@@ -42,9 +42,15 @@ export type Program = {
   new: boolean;
   low_confidence: boolean;
   navigators: ProgramNavigator[];
-  documents: Translation[];
+  documents: ProgramDocument[];
   warning_messages: Translation[];
 };
+
+export type ProgramDocument = {
+  text: Translation;
+  link: Translation;
+  link_text: Translation;
+}
 
 export type UrgentNeed = {
   name: Translation;

--- a/src/Types/Results.ts
+++ b/src/Types/Results.ts
@@ -52,7 +52,7 @@ export type Program = {
 
 export type ProgramDocument = {
   text: Translation;
-  link: Translation;
+  link_url: Translation;
   link_text: Translation;
 }
 


### PR DESCRIPTION
What (if any) features are you implementing?

- Documents have an optional link that is appended to the end of the document text.
- The link url and link text must be provided for the link to be displayed.
<img width="853" alt="Screenshot 2024-10-30 at 11 47 10 AM" src="https://github.com/user-attachments/assets/9d2e1c50-00e1-4828-95bb-1237c800c232">
<img width="859" alt="Screenshot 2024-10-29 at 4 24 34 PM" src="https://github.com/user-attachments/assets/c933a26e-4df9-40c2-9a36-f061a2083fe3">

Any other comments, questions, or concerns?
- This should be merged after [the benefits-api PR](https://github.com/Gary-Community-Ventures/benefits-api/pull/612).