### PR TITLE
1336/ Adding yearly option

### DIFF
--- a/src/Components/Confirmation/Confirmation.js
+++ b/src/Components/Confirmation/Confirmation.js
@@ -537,11 +537,13 @@ const Confirmation = () => {
       case 'monthly':
         num = Number(incomeAmount) * 12;
         break;
+      case 'yearly':
+        num = Number(incomeAmount);
+        break;
       case 'hourly':
         num = Number(incomeAmount) * Number(hoursPerWeek) * 52;
         break;
     }
-
     return `(${formatToUSD(num)}` + translatedAnnualText + `)`;
   };
 


### PR DESCRIPTION
What (if any) features are you implementing?

Fix for the issue #1336 , adding a yearly option to the switch statement.

Previous behavior: When In step 5, under question "How often are you paid this income: (Wages, salaries, tips)?" was selected frequency 'yearly', and for the question: "How much do you receive each pay period for: (Wages, salaries, tips)?" was inputed the amount -> Confirmation page would display zero.
![1](https://github.com/user-attachments/assets/1a362124-2b87-4ccb-a307-cb34de030cdb)
