### PR TITLE
Only allow integers in the household size field

### DIFF
--- a/src/Components/Steps/HouseholdSize.tsx
+++ b/src/Components/Steps/HouseholdSize.tsx
@@ -32,6 +32,7 @@ const HouseholdSize = () => {
           };
         },
       })
+      .int()
       .positive()
       .lte(8),
   });


### PR DESCRIPTION
What (if anything) did you refactor?
- Update the household size validation to only allow integers.