### PR TITLE
Fix: add the 'expense type' in parentheses + padding

### DIFF
--- a/src/Components/Steps/Expenses/Expenses.css
+++ b/src/Components/Steps/Expenses/Expenses.css
@@ -1,7 +1,7 @@
 .expense-section-container {
   position: relative;
   padding-bottom: 1rem;
-  margin-bottom: 1rem; 
+  margin-bottom: 1rem;
 }
 
 .first-expense-q-padding {

--- a/src/Components/Steps/Expenses/Expenses.css
+++ b/src/Components/Steps/Expenses/Expenses.css
@@ -1,7 +1,7 @@
 .expense-section-container {
   position: relative;
   padding-bottom: 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1rem;  
 }
 
 .first-expense-q-padding {
@@ -17,6 +17,10 @@
   width: 300vw;
   background: var(--secondary-background-color);
   z-index: -1;
+}
+
+.expense-section-container .expense-section-type {
+  margin-left: 0;
 }
 
 .expense-radiogroup-margin-bottom {

--- a/src/Components/Steps/Expenses/Expenses.css
+++ b/src/Components/Steps/Expenses/Expenses.css
@@ -1,7 +1,7 @@
 .expense-section-container {
   position: relative;
   padding-bottom: 1rem;
-  margin-bottom: 1rem;  
+  margin-bottom: 1rem; 
 }
 
 .first-expense-q-padding {

--- a/src/Components/Steps/Expenses/Expenses.tsx
+++ b/src/Components/Steps/Expenses/Expenses.tsx
@@ -228,7 +228,7 @@ const Expenses = () => {
                       <Select
                         {...field}
                         labelId={`expense-type-label-${index}`}
-                        id={`expenses.${index}.expenseSourceName`}                        
+                        id={`expenses.${index}.expenseSourceName`}
                         label={
                           <FormattedMessage
                             id="expenseBlock.createExpenseDropdownMenu-expenseTypeSelectLabel"

--- a/src/Components/Steps/Expenses/Expenses.tsx
+++ b/src/Components/Steps/Expenses/Expenses.tsx
@@ -123,7 +123,7 @@ const Expenses = () => {
 
   const getExpenseSourceLabel = (expenseOptions: Record<string, FormattedMessageType>, expenseSourceName: string) => {
     if (expenseSourceName) {
-      return <> ({expenseSourceName})</>;
+      return <> ({expenseOptions[expenseSourceName]})</>;
     }
   };
 
@@ -212,6 +212,7 @@ const Expenses = () => {
               <FormControl
                 sx={{ m: 1, minWidth: '13.125rem', maxWidth: '100%' }}
                 error={!!errors.expenses?.[index]?.expenseSourceName}
+                className="expense-section-type"
               >
                 <InputLabel id={`expense-type-label-${index}`}>
                   <FormattedMessage
@@ -227,7 +228,7 @@ const Expenses = () => {
                       <Select
                         {...field}
                         labelId={`expense-type-label-${index}`}
-                        id={`expenses.${index}.expenseSourceName`}
+                        id={`expenses.${index}.expenseSourceName`}                        
                         label={
                           <FormattedMessage
                             id="expenseBlock.createExpenseDropdownMenu-expenseTypeSelectLabel"


### PR DESCRIPTION
What (if anything) did you refactor?
- fix Step 6 - add the 'expense type' in parentheses
- fix padding in  'expense type' input field
Were there any issues that arose?
- step 6 [issue](https://github.com/Gary-Community-Ventures/benefits-calculator/issues/1419)

![image](https://github.com/user-attachments/assets/0f453524-7a36-4ddf-9c38-d5bc0e83d117)

