### PR TITLE
Redirect current benefits page to co white label

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,7 @@ const App = () => {
               <Route path="jeffcohs" element={<RedirectToWhiteLabel whiteLabel="co" />} />
               <Route path="jeffcohscm" element={<RedirectToWhiteLabel whiteLabel="co" />} />
               <Route path="ccig" element={<RedirectToWhiteLabel whiteLabel="co" />} />
+              <Route path="current-benefits" element={<RedirectToWhiteLabel whiteLabel="co" />} />
               <Route
                 path="step-1"
                 element={


### PR DESCRIPTION
What (if anything) did you refactor?
- Redirect the old current benefits page link to the `co` white label