### PR TITLE
Don't show category value when the value is 0

### DIFF
--- a/src/Components/Results/CategoryHeading/CategoryHeading.tsx
+++ b/src/Components/Results/CategoryHeading/CategoryHeading.tsx
@@ -59,7 +59,7 @@ const CategoryHeading = ({ category, showAmount = true }: CategoryHeadingProps) 
             <ResultsTranslate translation={category.name} />
           </h2>
         </div>
-        {showAmount && (
+        {showAmount && monthlyCategoryAmt !== 0 && (
           <div className="box-right">
             <h2 className="category-heading-text-style normal-weight">
               {translateNumber(formatToUSD(monthlyCategoryAmt))}


### PR DESCRIPTION
What (if anything) did you refactor?
- Don't show category value when the value is 0 on the results page.