### PR TITLE
Fix copy on Energy Calculator confirmation page

### DIFF
--- a/src/Components/EnergyCalculator/ConfirmationPage/Expenses.tsx
+++ b/src/Components/EnergyCalculator/ConfirmationPage/Expenses.tsx
@@ -21,9 +21,7 @@ export default function EnergyCalculatorExpenses() {
   return (
     <ConfirmationBlock
       icon={<Expense title={formatMessage(electricityProviderIconAlt)} />}
-      title={
-        <FormattedMessage id="energyCalculator.confirmation.expenses" defaultMessage="Utility Bills" />
-      }
+      title={<FormattedMessage id="energyCalculator.confirmation.expenses" defaultMessage="Utility Bills" />}
       editAriaLabel={editElectricityProviderAriaLabel}
       stepName="energyCalculatorExpenses"
     >

--- a/src/Components/EnergyCalculator/ConfirmationPage/Expenses.tsx
+++ b/src/Components/EnergyCalculator/ConfirmationPage/Expenses.tsx
@@ -22,7 +22,7 @@ export default function EnergyCalculatorExpenses() {
     <ConfirmationBlock
       icon={<Expense title={formatMessage(electricityProviderIconAlt)} />}
       title={
-        <FormattedMessage id="energyCalculator.confirmation.expenses" defaultMessage="Electric Utility Provider" />
+        <FormattedMessage id="energyCalculator.confirmation.expenses" defaultMessage="Utility Bills" />
       }
       editAriaLabel={editElectricityProviderAriaLabel}
       stepName="energyCalculatorExpenses"

--- a/src/Components/EnergyCalculator/ConfirmationPage/HouseholdData.tsx
+++ b/src/Components/EnergyCalculator/ConfirmationPage/HouseholdData.tsx
@@ -126,6 +126,8 @@ const EnergyCalcConfirmationHHData = () => {
             )}
           </ul>
         );
+      } else {
+        return <FormattedMessage id="confirmation.none" defaultMessage="None" />;
       }
     };
 


### PR DESCRIPTION
What (if anything) did you refactor?
- Rename the expense question title on the confirmation page
- Add "None" if the household member has no conditions