### PR TITLE
Add state to zip code error message

### DIFF
--- a/src/Components/FetchScreen/FetchScreen.tsx
+++ b/src/Components/FetchScreen/FetchScreen.tsx
@@ -213,8 +213,8 @@ const FetchScreen = () => {
     if (uuid === undefined) {
       if (whiteLabel !== undefined) {
         setWhiteLabel(whiteLabel);
-        setScreenLoading(false);
       }
+      setScreenLoading(false);
       return;
     }
     fetchScreen(uuid);

--- a/src/Components/Steps/Zipcode.tsx
+++ b/src/Components/Steps/Zipcode.tsx
@@ -17,14 +17,17 @@ import PrevAndContinueButtons from '../PrevAndContinueButtons/PrevAndContinueBut
 import { useDefaultBackNavigationFunction, useGoToNextStep } from '../QuestionComponents/questionHooks';
 import { handleNumbersOnly, NUM_PAD_PROPS } from '../../Assets/numInputHelpers';
 import useScreenApi from '../../Assets/updateScreen';
+import QuestionDescription from '../QuestionComponents/QuestionDescription';
 
 export const Zipcode = () => {
-  const { formData, setFormData } = useContext(Context);
+  const { formData, setFormData, getReferrer } = useContext(Context);
   const { uuid } = useParams();
   const backNavigationFunction = useDefaultBackNavigationFunction('zipcode');
   const { updateScreen } = useScreenApi();
 
+  const noChangeStateMessage = getReferrer('featureFlags').includes('no_zipcode_change_state');
   const countiesByZipcode = useConfig<{ [key: string]: { [key: string]: string } }>('counties_by_zipcode');
+  const state = useConfig<{ name: string }>('state');
 
   const checkCountyIsValid = ({ zipcode, county }: { zipcode: string; county: string }) => {
     const validCounties = countiesByZipcode[zipcode];
@@ -105,8 +108,16 @@ export const Zipcode = () => {
   };
 
   const getZipcodeHelperText = (hasZipcodeErrors: boolean) => {
-    if (!hasZipcodeErrors) return '';
-    return <FormattedMessage id="validation-helperText.zipcode" defaultMessage="Please enter a valid zip code" />;
+    if (!hasZipcodeErrors) {
+      return null;
+    }
+
+    return (
+      <>
+        <FormattedMessage id="validation-helperText.zipcode" defaultMessage="Please enter a valid zip code for " />
+        {state.name}
+      </>
+    );
   };
 
   const renderCountyHelperText = () => {
@@ -128,6 +139,20 @@ export const Zipcode = () => {
       <QuestionQuestion>
         <FormattedMessage id="questions.zipcode" defaultMessage="What is your zip code?" />
       </QuestionQuestion>
+      {!noChangeStateMessage && (
+        <QuestionDescription>
+          <FormattedMessage
+            id="questions.zipcode.description.1"
+            defaultMessage="If you are not filling out MyFriendBen in "
+          />
+          {state.name}
+          <FormattedMessage id="questions.zipcode.description.2" defaultMessage=", please click " />
+          <a href="/select-state" className="link-color">
+            <FormattedMessage id="questions.zipcode.description.link" defaultMessage="here" />
+          </a>
+          <FormattedMessage id="questions.zipcode.description.3" defaultMessage=" for other state options." />
+        </QuestionDescription>
+      )}
       <form onSubmit={handleSubmit(formSubmitHandler)}>
         <Controller
           name="zipcode"


### PR DESCRIPTION
What (if any) features are you implementing?
- Add state specific zip code error message.
- Add description that links to how to change your state.

![image](https://github.com/user-attachments/assets/eb7b6c17-8268-4639-8d57-33a7defd455c)

What (if anything) did you refactor?
- Fix reloading on the state page.

**I think that we should release this when NC goes live, so we don't link to a page with one state option.**

**I can change the select you state link easily**