### PR TITLE
Refactor/Removed 'manifest' link tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,6 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="MyFriendBen, a public benefits and public assistance screening tool." />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;700&family=Roboto:wght@300;400;500;700&family=Roboto+Slab:wght@300;400;700&display=swap"


### PR DESCRIPTION
What (if anything) did you refactor?
- Removed the `link` tag from `index.html` referencing `manifest.json`. This change makes it so that the browser (mobile & web) no longer shows the pop up prompt for installing a shortcut of the app.

Any other comments, questions, or concerns?
- [Link](https://stackoverflow.com/questions/45186993/what-is-public-manifest-json-file-in-create-react-app/45187030#45187030) to what the `manifest.json` does.
- We can also make modifications to the `manfiest.json` so that instead of entirely not showing the prompt, it shows up with 'MyFriendBen' name and custom icon:  
![Screenshot 2025-04-02 150626](https://github.com/user-attachments/assets/17d7fae9-92fc-49be-923c-54d46d550c40)

Closes #1594 