### PR TITLE
Energy: editing the zip code should not bring you back to the confirmation page

### DIFF
--- a/src/Components/Confirmation/ConfirmationSteps.tsx
+++ b/src/Components/Confirmation/ConfirmationSteps.tsx
@@ -22,7 +22,7 @@ import EnergyCalculatorUtilityStatus from '../EnergyCalculator/ConfirmationPage/
 import EnergyCalculatorApplianceStatus from '../EnergyCalculator/ConfirmationPage/ApplianceStatus';
 
 function ZipCode() {
-  const { formData } = useContext(Context);
+  const { formData, getReferrer } = useContext(Context);
   const { zipcode, county } = formData;
   const { formatMessage } = useIntl();
   const translateNumber = useTranslateNumber();
@@ -42,6 +42,7 @@ function ZipCode() {
       title={<FormattedMessage id="confirmation.residenceInfo" defaultMessage="Residence Information" />}
       editAriaLabel={editZipAriaLabel}
       stepName="zipcode"
+      noReturn={getReferrer('featureFlags').includes('no_confirmation_return_zipcode')}
     >
       <ConfirmationItem
         label={<FormattedMessage id="confirmation.displayAllFormData-zipcodeText" defaultMessage="Zip code: " />}


### PR DESCRIPTION
What (if any) features are you implementing?
- Add feature flag to not return you to the confirmation page for the zip code step.