### PR TITLE
Energy: Pass query params from the landing page

### DIFF
--- a/src/Components/EnergyCalculator/LandingPage/LandingPage.tsx
+++ b/src/Components/EnergyCalculator/LandingPage/LandingPage.tsx
@@ -7,11 +7,15 @@ import { ReactComponent as Apartment } from '../Icons/Apartment.svg';
 import { ReactComponent as Housing } from '../../../Assets/icons/General/residence.svg';
 import { CardActionArea, Card, Stack, CardContent, Box } from '@mui/material';
 import './LandingPage.css';
+import { useQueryString } from '../../QuestionComponents/questionHooks';
 
 const LandingPage = () => {
   useEffect(() => {
     document.title = OTHER_PAGE_TITLES.energyCalculatorLandingPage;
   }, []);
+
+  const homeownerQueryString = useQueryString();
+  const renterQueryString = useQueryString({ path: 'renter' });
 
   return (
     <main className="energy-calculator-container">
@@ -50,7 +54,7 @@ const LandingPage = () => {
           key="homeownerCard"
           sx={{ width: '15rem' }}
           className="card-action-area"
-          href="/co_energy_calculator/step-1"
+          href={`/co_energy_calculator/step-1${homeownerQueryString}`}
         >
           <Card className="option-card">
             <Stack direction="column" justifyContent="center" sx={{ flex: 1 }}>
@@ -67,7 +71,7 @@ const LandingPage = () => {
           key="renterCard"
           sx={{ width: '15rem' }}
           className="card-action-area"
-          href="/co_energy_calculator/step-1?path=renter"
+          href={`/co_energy_calculator/step-1${renterQueryString}`}
         >
           <Card className="option-card">
             <Stack direction="column" justifyContent="center" sx={{ flex: 1 }}>

--- a/src/Components/QuestionComponents/questionHooks.ts
+++ b/src/Components/QuestionComponents/questionHooks.ts
@@ -34,21 +34,34 @@ export function useGoToNextStep(questionName: QuestionName, routeEnding: string 
   };
 }
 
-export function useQueryString() {
+type MainQueryParamName = 'externalid' | 'referrer' | 'path' | 'test';
+export function useQueryString(override?: Partial<Record<MainQueryParamName, string>>) {
   const { formData } = useContext(Context);
   const query = new URLSearchParams();
 
-  if (formData.externalID !== undefined) {
-    query.append('externalid', formData.externalID);
-  }
+  const setParam = (name: MainQueryParamName, value: string | undefined, ...dontShowConditions: unknown[]) => {
+    let overrideValue = override?.[name];
+    if (overrideValue !== undefined) {
+      query.append(name, overrideValue);
+      return;
+    }
 
-  if (formData.immutableReferrer !== undefined && formData.immutableReferrer !== '') {
-    query.append('referrer', formData.immutableReferrer);
-  }
+    if (value === undefined) {
+      return;
+    }
+    for (const condition of dontShowConditions) {
+      if (value === condition) {
+        return;
+      }
+    }
 
-  if (formData.path !== undefined && formData.path !== 'default') {
-    query.append('path', formData.path);
-  }
+    query.append(name, value);
+  };
+
+  setParam('externalid', formData.externalID);
+  setParam('referrer', formData.immutableReferrer, '');
+  setParam('path', formData.path, 'default');
+  setParam('test', formData.isTest ? 'true' : undefined);
 
   let queryString = query.toString();
   if (queryString !== '') {

--- a/src/Components/QuestionComponents/questionHooks.ts
+++ b/src/Components/QuestionComponents/questionHooks.ts
@@ -35,7 +35,7 @@ export function useGoToNextStep(questionName: QuestionName, routeEnding: string 
 }
 
 type MainQueryParamName = 'externalid' | 'referrer' | 'path' | 'test';
-export function useQueryString(override?: Partial<Record<MainQueryParamName, string>>) {
+export function useQueryString(override?: Partial<Record<MainQueryParamName, string>>): string {
   const { formData } = useContext(Context);
   const query = new URLSearchParams();
 


### PR DESCRIPTION
What (if any) features are you implementing?
- Pass the query strings from the energy calculator landing page.

What (if anything) did you refactor?
- Add overrides to the `useQueryString` hook.