### PR TITLE
Refactor/Dynamic language attribute

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" translate="no">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="MyFriendBen, a public benefits and public assistance screening tool." />
+    <meta name="google" content="notranslate" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link
       rel="stylesheet"

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="MyFriendBen, a public benefits and public assistance screening tool." />
-    <meta name="google" content="notranslate" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link
       rel="stylesheet"

--- a/src/Components/HtmlLangUpdater/HtmlLangUpdater.tsx
+++ b/src/Components/HtmlLangUpdater/HtmlLangUpdater.tsx
@@ -1,0 +1,18 @@
+import { useContext, useEffect } from 'react';
+import { Context } from '../Wrapper/Wrapper';
+
+/**
+ * This component updates the lang attribute on the 'index.html'
+ * based on the langauge coming from 'locale' context.
+ */
+export const HtmlLangUpdater = () => {
+  const { locale } = useContext(Context);
+
+  useEffect(() => {
+    const htmlLang = locale.slice(0, 2);
+    document.documentElement.setAttribute('lang', htmlLang);
+
+  }, [locale]);
+
+  return null;
+};

--- a/src/Components/HtmlLangUpdater/HtmlLangUpdater.tsx
+++ b/src/Components/HtmlLangUpdater/HtmlLangUpdater.tsx
@@ -1,9 +1,11 @@
 import { useContext, useEffect } from 'react';
 import { Context } from '../Wrapper/Wrapper';
+import LANGUAGE_OPTIONS, { Language } from '../../Assets/languageOptions';
 
 /**
- * This component updates the lang attribute on the 'index.html'
- * based on the langauge coming from 'locale' context.
+ * This component updates the 'lang' attribute on the HTML
+ * element to prevent Google Translate from overriding our
+ * translations, but only for languages from LANGUAGE_OPTIONS.
  */
 export const HtmlLangUpdater = () => {
   const { locale } = useContext(Context);
@@ -11,6 +13,20 @@ export const HtmlLangUpdater = () => {
   useEffect(() => {
     const htmlLang = locale.slice(0, 2);
     document.documentElement.setAttribute('lang', htmlLang);
+
+    if (htmlLang !== 'en') {
+      const supportedLanguageCodes = Object.keys(LANGUAGE_OPTIONS).map(
+        (langKey) => (langKey as Language).slice(0, 2)
+      );
+
+      if (supportedLanguageCodes.includes(htmlLang)) {
+        document.documentElement.setAttribute('translate', 'no');
+      } else {
+        document.documentElement.removeAttribute('translate');
+      }
+    } else {
+      document.documentElement.removeAttribute('translate');
+    }
 
   }, [locale]);
 

--- a/src/Components/Wrapper/Wrapper.tsx
+++ b/src/Components/Wrapper/Wrapper.tsx
@@ -119,11 +119,7 @@ const Wrapper = (props: PropsWithChildren<{}>) => {
 
   let [translations, setTranslations] = useState<{ Language: { [key: string]: string } } | {}>({});
 
-  const [theme, setTheme, styleOverride] = useStyle('default');
-  const [locale, setLocale] = useState<Language>('en-us');
-  const [messages, setMessages] = useState({});
-
-  useEffect(() => {
+  const initializeLocale = () => {
     let defaultLanguage = localStorage.getItem('language') as Language;
 
     const userLanguage = navigator.language.toLowerCase() as Language;
@@ -144,8 +140,12 @@ const Wrapper = (props: PropsWithChildren<{}>) => {
       }
     });
 
-    setLocale(defaultLanguage);
-  }, [languages.length]);
+    return defaultLanguage;
+  };
+
+  const [theme, setTheme, styleOverride] = useStyle('default');
+  const [locale, setLocale] = useState<Language>(initializeLocale);
+  const [messages, setMessages] = useState({});
 
   useEffect(() => {
     if (locale in translations) {
@@ -154,7 +154,9 @@ const Wrapper = (props: PropsWithChildren<{}>) => {
 
     setTranslationsLoading(true);
     getTranslations(locale).then((value) => {
-      setTranslations({ ...translations, ...value });
+      setTranslations((translations) => {
+        return { ...translations, ...value };
+      });
     });
   }, [locale]);
 

--- a/src/Components/Wrapper/Wrapper.tsx
+++ b/src/Components/Wrapper/Wrapper.tsx
@@ -7,6 +7,7 @@ import { getTranslations } from '../../apiCalls';
 import useReferrer, { ReferrerData } from '../Referrer/referrerHook';
 import { useGetConfig } from '../Config/configHook';
 import { rightToLeftLanguages, Language } from '../../Assets/languageOptions';
+import { HtmlLangUpdater } from '../HtmlLangUpdater/HtmlLangUpdater';
 
 const initialFormData: FormData = {
   whiteLabel: '_default',
@@ -217,6 +218,7 @@ const Wrapper = (props: PropsWithChildren<{}>) => {
       }}
     >
       <IntlProvider locale={locale} messages={messages} defaultLocale={locale}>
+        <HtmlLangUpdater />
         {props.children}
       </IntlProvider>
     </Context.Provider>


### PR DESCRIPTION
What (if anything) did you refactor?
- Refactored the `index.html` to not accept translation requests from the browser's Google Translate if the current selected language is from one our supported languages.
- Added a new component to dynamically update the `lang` attribute of `index.html` based on the `locale` language variable from the context. This component also adds a `translate=no` attribute whenever the selected language in the screener is from one of our supported languages (except English). This is meant to prevent overriding of our translated texts with browser's Google Translate. 