### PR TITLE
Central: Fix cobranded icon colors on the results page

### DIFF
--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -26,6 +26,13 @@
   fill: var(--secondary-background-color);
 }
 
+.header-icon-box path,
+.header-icon-box rect,
+.header-icon-box circle {
+  fill: var(--icon-color);
+  stroke: var(--icon-color);
+}
+
 .header-text {
   display: flex;
   flex-direction: column;

--- a/src/Components/Results/Results.css
+++ b/src/Components/Results/Results.css
@@ -66,8 +66,11 @@
   width: 2.5rem;
 }
 
-.category-heading-icon svg path {
+.category-heading-icon svg path,
+.category-heading-icon svg rect,
+.category-heading-icon svg circle {
   fill: var(--icon-color);
+  stroke: var(--icon-color);
 }
 
 .category-heading-column {


### PR DESCRIPTION
What (if anything) did you refactor?
- Use the cobranded icon color on the results page.