### PR TITLE
Bug/Made `co_care` selectable in step-8

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -70,6 +70,7 @@ export function useUpdateFormData() {
         ma_maeitc: response.has_ma_maeitc ?? false,
         ma_macfc: response.has_ma_macfc ?? false,
         co_andso: response.has_co_andso ?? false,
+        co_care: response.has_co_care ?? false,
       },
       referralSource: response.referral_source ?? undefined,
       immutableReferrer: response.referrer_code ?? undefined,

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -82,6 +82,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     has_ma_maeitc: formData.benefits.ma_maeitc ?? null,
     has_ma_macfc: formData.benefits.ma_macfc ?? null,
     has_co_andso: formData.benefits.co_andso ?? null,
+    has_co_care: formData.benefits.co_care ?? null,
     referral_source: formData.referralSource ?? null,
     referrer_code: formData.immutableReferrer ?? null,
     path: formData.path ?? null,

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -191,6 +191,7 @@ export type ApiFormData = {
   has_ma_maeitc: boolean | null;
   has_ma_macfc: boolean | null;
   has_co_andso: boolean | null;
+  has_co_care: boolean | null;
   has_employer_hi?: boolean | null;
   has_private_hi?: boolean | null;
   has_medicaid_hi?: boolean | null;


### PR DESCRIPTION
What (if anything) did you refactor?
- Made the `co_care` (Colorado's Affordable Residential Energy (CARE) via Energy Outreach Colorado) selectable in step-8.
