### PR TITLE
Energy: Renter path bug on landing page

### DIFF
--- a/src/Components/EnergyCalculator/LandingPage/LandingPage.tsx
+++ b/src/Components/EnergyCalculator/LandingPage/LandingPage.tsx
@@ -14,7 +14,7 @@ const LandingPage = () => {
     document.title = OTHER_PAGE_TITLES.energyCalculatorLandingPage;
   }, []);
 
-  const homeownerQueryString = useQueryString();
+  const homeownerQueryString = useQueryString({ path: null });
   const renterQueryString = useQueryString({ path: 'renter' });
 
   return (

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -16,6 +16,7 @@ const Header = () => {
   const { formData, getReferrer, whiteLabel } = context;
   const languageOptions = useConfig<{ [key: string]: string }>('language_options');
   const queryString = useQueryString();
+  const landingPageQueryString = useQueryString({ path: null });
   const intl = useIntl();
   const logoClass = getReferrer('logoClass', 'logo');
 
@@ -25,7 +26,7 @@ const Header = () => {
     }
 
     if (getReferrer('featureFlags').includes('logo_landing_page_link')) {
-      return `/${whiteLabel}/landing-page${queryString}`;
+      return `/${whiteLabel}/landing-page${landingPageQueryString}`;
     }
 
     return `/${whiteLabel}/step-1${queryString}`;

--- a/src/Components/QuestionComponents/questionHooks.ts
+++ b/src/Components/QuestionComponents/questionHooks.ts
@@ -35,12 +35,17 @@ export function useGoToNextStep(questionName: QuestionName, routeEnding: string 
 }
 
 type MainQueryParamName = 'externalid' | 'referrer' | 'path' | 'test';
-export function useQueryString(override?: Partial<Record<MainQueryParamName, string>>): string {
+export function useQueryString(override?: Partial<Record<MainQueryParamName, string | null>>): string {
   const { formData } = useContext(Context);
   const query = new URLSearchParams();
 
   const setParam = (name: MainQueryParamName, value: string | undefined, ...dontShowConditions: unknown[]) => {
     let overrideValue = override?.[name];
+
+    if (overrideValue === null) {
+      return;
+    }
+
     if (overrideValue !== undefined) {
       query.append(name, overrideValue);
       return;


### PR DESCRIPTION
What (if any) features are you implementing?
- Add ability to force remove param.
- Don't keep the path param when going to the landing page.
- Don't have a path param when clicking the homeowner button.