### PR TITLE
Central: Add warning message link

### DIFF
--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -203,7 +203,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
       </div>
       <div className="results-program-page-warning-container">
         {warningMessages.map((warning, key) => {
-          return <WarningMessage message={warning.message} key={key} />;
+          return <WarningMessage warning={warning} key={key} />;
         })}
       </div>
       <div className="apply-button-container">

--- a/src/Components/WarningComponent/WarningMessage.css
+++ b/src/Components/WarningComponent/WarningMessage.css
@@ -17,3 +17,7 @@
   height: 2rem;
   fill: #ff0000;
 }
+
+.warning-message-link {
+  padding-left: 0.25rem;
+}

--- a/src/Components/WarningComponent/WarningMessage.tsx
+++ b/src/Components/WarningComponent/WarningMessage.tsx
@@ -4,15 +4,26 @@ import ResultsTranslate from '../Results/Translate/Translate';
 import { Translation } from '../../Types/Results';
 
 type WarningMessageProps = {
-  message: Translation;
+  warning: {
+    message: Translation;
+    link_url: Translation;
+    link_text: Translation;
+  }
 };
 
-const WarningMessage = ({ message }: WarningMessageProps) => {
+const WarningMessage = ({ warning }: WarningMessageProps) => {
   return (
     <div className="warning-message">
       <WarningIcon className="warning-icon" />
       <p>
-        <ResultsTranslate translation={message} />
+        <ResultsTranslate translation={warning.message} />
+        {warning.link_url.default_message && warning.link_text.default_message && (
+            <span className="warning-message-link">
+              <a href={warning.link_url.default_message} target="_blank" className="link-color">
+                <ResultsTranslate translation={warning.link_text} />
+              </a>
+            </span>
+          )}
       </p>
     </div>
   );

--- a/src/Components/WarningComponent/WarningMessage.tsx
+++ b/src/Components/WarningComponent/WarningMessage.tsx
@@ -1,25 +1,32 @@
 import { ReactComponent as WarningIcon } from '../../Assets/icons/General/warning.svg';
 import './WarningMessage.css';
 import ResultsTranslate from '../Results/Translate/Translate';
-import { Translation } from '../../Types/Results';
+import { WarningMsg } from '../../Types/Results';
+import { useIntl } from 'react-intl';
 
 type WarningMessageProps = {
-  warning: {
-    message: Translation;
-    link_url: Translation;
-    link_text: Translation;
-  };
+  warning: WarningMsg;
 };
 
 const WarningMessage = ({ warning }: WarningMessageProps) => {
+  const intl = useIntl();
+
+  let translatedLink = '';
+  if (warning.link_url.default_message !== '') {
+    translatedLink = intl.formatMessage({
+      id: warning.link_url.label,
+      defaultMessage: warning.link_url.default_message,
+    });
+  }
+
   return (
     <div className="warning-message">
       <WarningIcon className="warning-icon" />
       <p>
         <ResultsTranslate translation={warning.message} />
-        {warning.link_url.default_message && warning.link_text.default_message && (
+        {translatedLink !== '' && (
           <span className="warning-message-link">
-            <a href={warning.link_url.default_message} target="_blank" className="link-color">
+            <a href={translatedLink} target="_blank" className="link-color">
               <ResultsTranslate translation={warning.link_text} />
             </a>
           </span>

--- a/src/Components/WarningComponent/WarningMessage.tsx
+++ b/src/Components/WarningComponent/WarningMessage.tsx
@@ -8,7 +8,7 @@ type WarningMessageProps = {
     message: Translation;
     link_url: Translation;
     link_text: Translation;
-  }
+  };
 };
 
 const WarningMessage = ({ warning }: WarningMessageProps) => {
@@ -18,12 +18,12 @@ const WarningMessage = ({ warning }: WarningMessageProps) => {
       <p>
         <ResultsTranslate translation={warning.message} />
         {warning.link_url.default_message && warning.link_text.default_message && (
-            <span className="warning-message-link">
-              <a href={warning.link_url.default_message} target="_blank" className="link-color">
-                <ResultsTranslate translation={warning.link_text} />
-              </a>
-            </span>
-          )}
+          <span className="warning-message-link">
+            <a href={warning.link_url.default_message} target="_blank" className="link-color">
+              <ResultsTranslate translation={warning.link_text} />
+            </a>
+          </span>
+        )}
       </p>
     </div>
   );

--- a/src/Types/Results.ts
+++ b/src/Types/Results.ts
@@ -25,7 +25,7 @@ export type ProgramCategoryCap = {
   member_caps: { [key: string]: number } | null;
 };
 
-export type WarningMessage = {
+export type WarningMsg = {
   message: Translation;
   link_url: Translation;
   link_text: Translation;

--- a/src/Types/Results.ts
+++ b/src/Types/Results.ts
@@ -27,6 +27,8 @@ export type ProgramCategoryCap = {
 
 export type WarningMessage = {
   message: Translation;
+  link_url: Translation;
+  link_text: Translation;
   legal_statuses: CitizenLabels[];
 };
 


### PR DESCRIPTION
What (if any) features are you implementing?
- Add optional url link and text to warning message
- Example,
  ><img width="350" alt="Screenshot 2025-05-21 at 10 18 16 AM" src="https://github.com/user-attachments/assets/4f55c0ac-ddc0-48fa-b7d7-fa2348dc5e92" />

Any other comments, questions, or concerns?
- Merge after [backend PR](https://github.com/Gary-Community-Ventures/benefits-api/pull/979)