### PR TITLE
Add fallback URLs for privacy and consent links when not found in config

### DIFF
--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -247,5 +247,11 @@ export function useLocalizedLink(configKey: 'privacy_policy' | 'consent_to_conta
   const { locale } = useContext(Context);
   const links = useConfig<Partial<Record<Language, string>>>(configKey, {});
 
-  return links[locale] ?? links['en-us'] ?? '';
+  // Fallback URLs if not found in config
+  const fallbackUrls = {
+    privacy_policy: 'https://www.myfriendben.org/privacy-policy/',
+    consent_to_contact: 'https://www.myfriendben.org/terms-and-conditions/',
+  };
+
+  return links[locale] ?? links['en-us'] ?? fallbackUrls[configKey] ?? '';
 }


### PR DESCRIPTION
What (if any) features are you implementing?
-

Fixes Bug: Privacy Policy Link on Language & State selector page if state isn't predetermined #1758

The cause of the bug is that the links for privacy policy and terms & conditions are store in the localized data once the whitelabel is selected. See below for a possible better longer term resolution.

What (if anything) did you refactor?
-
Were there any issues that arose?
-
Is there anything that you need from your teammate?
-
Any other comments, questions, or concerns?
-
I don't love this fix but it will resolve the bug quickly for en-us users. A better solution might be to include the link data in the translations API call. Given my newness to the project, I'll connect with others to discuss the potential impact. But my initial instinct says it'd be great for the interface for translations to match the interface for the local implementation. 
