### PR TITLE
Add terms and conditions to footer

### DIFF
--- a/src/Components/Footer/Footer.css
+++ b/src/Components/Footer/Footer.css
@@ -51,7 +51,15 @@
 .policy-link {
   text-decoration: none;
   color: #fff;
-  margin-bottom: 1rem;
+  margin: 0 1rem 1rem;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.policy-link-separator {
+  color: #fff;
+  font-weight: bold;
+  text-transform: uppercase;
 }
 
 @media (max-width: 700px) {

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -11,6 +11,7 @@ import { FooterDataConfig } from '../../Types/Config';
 const Footer = () => {
   const footerData: FooterDataConfig = useConfig('footer_data');
   const privacyPolicyLink = useLocalizedLink('privacy_policy');
+  const termsAndConditionsLink = useLocalizedLink('consent_to_contact');
   const context = useContext(Context);
   const { getReferrer } = context;
 
@@ -44,6 +45,9 @@ const Footer = () => {
         <div className="footer-policy-container">
           <a href={privacyPolicyLink} target="_blank" className="policy-link">
             <FormattedMessage id="footer.privacyPolicy" defaultMessage="Privacy Policy" />
+          </a>
+          <a href={termsAndConditionsLink} target="_blank" className="policy-link">
+            <FormattedMessage id="footer.termsAndConditions" defaultMessage="Terms and Conditions" />
           </a>
         </div>
       </Paper>


### PR DESCRIPTION
What (if any) features are you implementing?
-

We need Terms and Conditions to appear in the footer similar to the MFB WordPress site.

![terms_and_conditions](https://github.com/user-attachments/assets/46c88616-2e92-4829-987d-69c52f364c3d)

What (if anything) did you refactor?
-
Were there any issues that arose?
-
Is there anything that you need from your teammate?
-
Any other comments, questions, or concerns?
-

**TODO:**

- [ ] Add `footer.termsAndConditions` to translations