### PR TITLE
Improve UX for updating immediate needs

### DIFF
--- a/src/Components/QuestionComponents/questionHooks.ts
+++ b/src/Components/QuestionComponents/questionHooks.ts
@@ -7,7 +7,12 @@ import { Context } from '../Wrapper/Wrapper';
 
 export function useShouldRedirectToConfirmation() {
   const location = useLocation();
-  return isCustomTypedLocationState(location.state);
+  return isCustomTypedLocationState(location.state) && location.state.routedFromConfirmationPg;
+}
+
+export function useShouldRedirectToResults() {
+  const location = useLocation();
+  return isCustomTypedLocationState(location.state) && location.state.routeBackToResults;
 }
 
 // routeEnding will be added to the end of the route when going to the next step
@@ -17,11 +22,17 @@ export function useGoToNextStep(questionName: QuestionName, routeEnding: string 
   const stepDirectory = useStepDirectory();
   const totalStepCount = stepDirectory.length + STARTING_QUESTION_NUMBER - 1;
   const redirectToConfirmationPage = useShouldRedirectToConfirmation();
+  const redirectToResults = useShouldRedirectToResults();
   const navigate = useNavigate();
 
   return () => {
     if (redirectToConfirmationPage) {
       navigate(`/${whiteLabel}/${uuid}/confirm-information`);
+      return;
+    }
+
+    if (redirectToResults) {
+      navigate(`/${whiteLabel}/${uuid}/results/near-term-needs`);
       return;
     }
 

--- a/src/Components/Results/Needs/Needs.tsx
+++ b/src/Components/Results/Needs/Needs.tsx
@@ -25,12 +25,10 @@ const Needs = () => {
       <InformationalText>
         <FormattedMessage
           id="nearTermBenefits.editSelections"
-          defaultMessage="If you would like to see additional types of resources, please edit your selections in {thisStepLink}."
+          defaultMessage="If you would like to see additional types of resources, please edit your selections in <link>this step</link>."
           values={{
-            thisStepLink: (
-              <Link to={immediateNeedsLink}>
-                <FormattedMessage id="nearTermBenefits.thisStep" defaultMessage="this step" />
-              </Link>
+            link: (chunks) => (
+              <Link to={immediateNeedsLink} state={{ routeBackToResults: true }}>{chunks}</Link>
             ),
           }}
         />

--- a/src/Components/Steps/HouseholdMembers/HouseholdMemberForm.tsx
+++ b/src/Components/Steps/HouseholdMembers/HouseholdMemberForm.tsx
@@ -483,7 +483,7 @@ const HouseholdMemberForm = () => {
           <QuestionDescription>
             <FormattedMessage
               id="insurance.chooseAllThatApply"
-              defaultMessage="Choose all that apply"
+              defaultMessage="Choose all that apply."
             />
           </QuestionDescription>
           <RHFOptionCardGroup

--- a/src/Types/FormData.ts
+++ b/src/Types/FormData.ts
@@ -110,6 +110,7 @@ export type Conditions = {
 
 export const isCustomTypedLocationState = (
   locationState: unknown,
-): locationState is { routedFromConfirmationPg: boolean } => {
-  return typeof locationState === 'object' && locationState !== null && 'routedFromConfirmationPg' in locationState;
+): locationState is { routedFromConfirmationPg?: boolean; routeBackToResults?: boolean } => {
+  return typeof locationState === 'object' && locationState !== null && 
+    ('routedFromConfirmationPg' in locationState || 'routeBackToResults' in locationState);
 };


### PR DESCRIPTION
What (if any) features are you implementing?
-

QA'ing for release uncovered a few adjustments that needed to be made.

When a user ended up on the Additional Resources/Immediate Needs page, the link to return to edit the immediate needs wasn't editable for each language. Updated the implementation to leverage React Intl's rich text formatting.

The user also would need to step through all remaining steps again after hitting the `Continue` button instead of being returned to the results page. This update returns them back to the page they are coming from.


What (if anything) did you refactor?
-
Were there any issues that arose?
-
Is there anything that you need from your teammate?
-
Any other comments, questions, or concerns?
-

I see two implementations now where we want to route to pages that differ from the standard flow. I wonder if updating our implementation to support something like `redirectTo: <SOME_TARGET>` might be better but I didn't want to mess up state so figured I'd do something I know will work while I'm still getting a feel for the code base. Would love to hear ideas on this if anyone has them as my implementation feels a little code smelly.