### PR TITLE
Fixes County Dropdown Resetting #1798

### DIFF
--- a/src/Components/Steps/Zipcode.tsx
+++ b/src/Components/Steps/Zipcode.tsx
@@ -92,17 +92,25 @@ export const Zipcode = () => {
   const countyKeys = counties ? Object.keys(counties) : [];
 
   useEffect(() => {
-    if (parsedZipCode.success) {
-      const counties = countiesByZipcode[parsedZipCode.data];
-      const countyKeys = Object.keys(counties);
-
-      if (countyKeys.length === 1) {
-        setValue('county', countyKeys[0]);
-      } else {
-        setValue('county', 'disabled-select');
-      }
+    if (!parsedZipCode.success) return; // guard clause
+  
+    const counties     = countiesByZipcode[parsedZipCode.data] || {};
+    const countyKeys   = Object.keys(counties);
+    const currentCounty = watch('county');
+  
+    // If there’s exactly one county, select it
+    if (countyKeys.length === 1) {
+      if (currentCounty !== countyKeys[0]) setValue('county', countyKeys[0]);
+      return;
     }
-  }, [parsedZipCode, setValue, countiesByZipcode]);
+  
+    // More than one county: set to disabled-select if the current county is invalid
+    const isValid = countyKeys.includes(currentCounty) && currentCounty !== 'disabled-select';
+    if (!isValid && currentCounty !== 'disabled-select') {
+      setValue('county', 'disabled-select');
+    }
+  }, [parsedZipCode, countiesByZipcode, watch, setValue]);
+  
 
   const formSubmitHandler = async (zipCodeAndCountyData: FormSchema) => {
     if (uuid === undefined) {


### PR DESCRIPTION
What (if anything) did you refactor?
- County dropdown now remembers selection. Now correctly preserves valid county selections
while still validating against the current zipcode. 
- If there's only one county selection, it'll automatically choose it.


https://github.com/user-attachments/assets/9d774630-3dbe-4c45-8834-6a2997071283

