### PR TITLE
Energy: Fix 'Learn More' button alignment bug

### DIFF
--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -349,7 +349,7 @@ function RequiredProgram({ programId }: RequiredProgramProps) {
       <p>
         <ResultsTranslate translation={program.description} />
       </p>
-      <div className="result-program-more-info-button">
+      <div className="result-program-learn-more-button">
         <Link to={programLink}>
           <FormattedMessage id="programPage.requiredPrograms.link" defaultMessage="Learn More" />
         </Link>

--- a/src/Components/Results/Programs/ProgramCard.css
+++ b/src/Components/Results/Programs/ProgramCard.css
@@ -58,7 +58,7 @@
   color: inherit;
 }
 
-.result-program-more-info-button a {
+.result-program-more-info-button a, .result-program-learn-more-button a {
   color: white;
   text-decoration: none;
   font-size: 0.8rem;
@@ -214,7 +214,7 @@ h1.header-text-bottom {
     transform: translateY(-50%);
   }
 
-  .result-program-more-info-button a {
+  .result-program-more-info-button a, .result-program-learn-more-button a {
     padding: 0.5rem 1rem;
   }
 


### PR DESCRIPTION
### What (if any) features are you implementing?
- Add a new class to `RequiredProgram`'s 'Learn More' link so that it can be styled independently. Then apply the link styling to the new class, but omit the [absolute positioning](https://github.com/Gary-Community-Ventures/benefits-calculator/blob/main/src/Components/Results/Programs/ProgramCard.css#L210-L215) that was causing the issue on the program's 'More Info' view.

#### Before:
<img width="1246" height="1220" alt="Screenshot 2025-07-31 at 4 11 09 PM" src="https://github.com/user-attachments/assets/8a55f64d-fe7f-4881-9bcf-28c724677520" />

#### After:
<img width="1246" height="1220" alt="Screenshot 2025-07-31 at 4 10 09 PM" src="https://github.com/user-attachments/assets/d175af83-7338-4fe0-96f3-f1b64e180ca7" />