### PR TITLE
Feat/Cobrand-Referrers default language

### DIFF
--- a/src/Components/Referrer/referrerHook.tsx
+++ b/src/Components/Referrer/referrerHook.tsx
@@ -21,6 +21,7 @@ export type ReferrerData = {
   featureFlags: ReferrerOptions<string[]>;
   stepDirectory: ReferrerOptions<StepDirectory>;
   noResultMessage: ReferrerOptions<FormattedMessageType>;
+  defaultLanguage: ReferrerOptions<string>;
 };
 
 export type ReferrerDataValue<T extends keyof ReferrerData> = T extends
@@ -31,6 +32,7 @@ export type ReferrerDataValue<T extends keyof ReferrerData> = T extends
   | 'footerLogoClass'
   | 'logoClass'
   | 'shareLink'
+  | 'defaultLanguage'
   ? string
   : T extends 'logoAlt' | 'logoFooterAlt'
   ? { id: string; defaultMessage: string }

--- a/src/Components/Wrapper/Wrapper.tsx
+++ b/src/Components/Wrapper/Wrapper.tsx
@@ -189,6 +189,17 @@ const Wrapper = (props: PropsWithChildren<{}>) => {
     document.documentElement.removeAttribute('dir');
   }, [locale]);
 
+  useEffect(() => {
+    if (!referrerData) return;
+    const defaultLang = getReferrer('defaultLanguage', 'en-us');
+    const theme = getReferrer('theme', 'default');
+
+    const isCobrand = theme !== 'default';
+    if (isCobrand && defaultLang !== 'en-us') {
+      setLocale(defaultLang as Language);
+    }
+  }, [referrerData]);
+
   const selectLanguage = (newLocale: string) => {
     if (languages.every((lang) => lang !== newLocale)) {
       setLocale('en-us');

--- a/src/Components/Wrapper/Wrapper.tsx
+++ b/src/Components/Wrapper/Wrapper.tsx
@@ -191,12 +191,10 @@ const Wrapper = (props: PropsWithChildren<{}>) => {
 
   useEffect(() => {
     if (!referrerData) return;
-    const defaultLang = getReferrer('defaultLanguage', 'en-us');
-    const theme = getReferrer('theme', 'default');
-
-    const isCobrand = theme !== 'default';
-    if (isCobrand && defaultLang !== 'en-us') {
-      setLocale(defaultLang as Language);
+    const defaultLanguage = getReferrer('defaultLanguage', 'en-us');
+    
+    if (defaultLanguage !== 'en-us') {
+      setLocale(defaultLanguage as Language);
     }
   }, [referrerData]);
 


### PR DESCRIPTION
What (if anything) did you refactor?
- Added a `useEffect` hook to update the default language of the screener only for `referrers` that has a default language set using a new `defaultLanguage` object in its whitelabel's configuration record.

Any other comments, questions, or concerns?
- Please follow the setup steps in this PR [#1097](https://github.com/Gary-Community-Ventures/benefits-api/pull/1097) to update the configuration records.